### PR TITLE
feat: WASM core with color-sorted sublattice sweep

### DIFF
--- a/ising-core/.appveyor.yml
+++ b/ising-core/.appveyor.yml
@@ -1,0 +1,11 @@
+install:
+  - appveyor-retry appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - if not defined RUSTFLAGS rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain nightly
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - rustc -V
+  - cargo -V
+
+build: false
+
+test_script:
+  - cargo test --locked

--- a/ising-core/.github/dependabot.yml
+++ b/ising-core/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "08:00"
+  open-pull-requests-limit: 10

--- a/ising-core/.gitignore
+++ b/ising-core/.gitignore
@@ -1,0 +1,6 @@
+/target
+**/*.rs.bk
+Cargo.lock
+bin/
+pkg/
+wasm-pack.log

--- a/ising-core/.travis.yml
+++ b/ising-core/.travis.yml
@@ -1,0 +1,69 @@
+language: rust
+sudo: false
+
+cache: cargo
+
+matrix:
+  include:
+
+  # Builds with wasm-pack.
+  - rust: beta
+    env: RUST_BACKTRACE=1
+    addons:
+      firefox: latest
+      chrome: stable
+    before_script:
+      - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
+      - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
+      - cargo install-update -a
+      - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -f
+    script:
+      - cargo generate --git . --name testing
+      # Having a broken Cargo.toml (in that it has curlies in fields) anywhere
+      # in any of our parent dirs is problematic.
+      - mv Cargo.toml Cargo.toml.tmpl
+      - cd testing
+      - wasm-pack build
+      - wasm-pack test --chrome --firefox --headless
+
+  # Builds on nightly.
+  - rust: nightly
+    env: RUST_BACKTRACE=1
+    before_script:
+      - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
+      - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
+      - cargo install-update -a
+      - rustup target add wasm32-unknown-unknown
+    script:
+      - cargo generate --git . --name testing
+      - mv Cargo.toml Cargo.toml.tmpl
+      - cd testing
+      - cargo check
+      - cargo check --target wasm32-unknown-unknown
+      - cargo check                                 --no-default-features
+      - cargo check --target wasm32-unknown-unknown --no-default-features
+      - cargo check                                 --no-default-features --features console_error_panic_hook
+      - cargo check --target wasm32-unknown-unknown --no-default-features --features console_error_panic_hook
+      - cargo check                                 --no-default-features --features "console_error_panic_hook wee_alloc"
+      - cargo check --target wasm32-unknown-unknown --no-default-features --features "console_error_panic_hook wee_alloc"
+
+  # Builds on beta.
+  - rust: beta
+    env: RUST_BACKTRACE=1
+    before_script:
+      - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
+      - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
+      - cargo install-update -a
+      - rustup target add wasm32-unknown-unknown
+    script:
+      - cargo generate --git . --name testing
+      - mv Cargo.toml Cargo.toml.tmpl
+      - cd testing
+      - cargo check
+      - cargo check --target wasm32-unknown-unknown
+      - cargo check                                 --no-default-features
+      - cargo check --target wasm32-unknown-unknown --no-default-features
+      - cargo check                                 --no-default-features --features console_error_panic_hook
+      - cargo check --target wasm32-unknown-unknown --no-default-features --features console_error_panic_hook
+      # Note: no enabling the `wee_alloc` feature here because it requires
+      # nightly for now.

--- a/ising-core/Cargo.toml
+++ b/ising-core/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "ising-core"
+version = "0.1.0"
+authors = ["Naoki Watanabe <asterisk37n@gmail.com>"]
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["console_error_panic_hook"]
+
+[dependencies]
+wasm-bindgen = "0.2"
+console_error_panic_hook = { version = "0.1.7", optional = true }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+
+[profile.release]
+opt-level = 3
+lto = true

--- a/ising-core/LICENSE_APACHE
+++ b/ising-core/LICENSE_APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/ising-core/LICENSE_MIT
+++ b/ising-core/LICENSE_MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2018 Naoki Watanabe <asterisk37n@gmail.com>
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/ising-core/README.md
+++ b/ising-core/README.md
@@ -1,0 +1,84 @@
+<div align="center">
+
+  <h1><code>wasm-pack-template</code></h1>
+
+  <strong>A template for kick starting a Rust and WebAssembly project using <a href="https://github.com/rustwasm/wasm-pack">wasm-pack</a>.</strong>
+
+  <p>
+    <a href="https://travis-ci.org/rustwasm/wasm-pack-template"><img src="https://img.shields.io/travis/rustwasm/wasm-pack-template.svg?style=flat-square" alt="Build Status" /></a>
+  </p>
+
+  <h3>
+    <a href="https://rustwasm.github.io/docs/wasm-pack/tutorials/npm-browser-packages/index.html">Tutorial</a>
+    <span> | </span>
+    <a href="https://discordapp.com/channels/442252698964721669/443151097398296587">Chat</a>
+  </h3>
+
+  <sub>Built with 🦀🕸 by <a href="https://rustwasm.github.io/">The Rust and WebAssembly Working Group</a></sub>
+</div>
+
+## About
+
+[**📚 Read this template tutorial! 📚**][template-docs]
+
+This template is designed for compiling Rust libraries into WebAssembly and
+publishing the resulting package to NPM.
+
+Be sure to check out [other `wasm-pack` tutorials online][tutorials] for other
+templates and usages of `wasm-pack`.
+
+[tutorials]: https://rustwasm.github.io/docs/wasm-pack/tutorials/index.html
+[template-docs]: https://rustwasm.github.io/docs/wasm-pack/tutorials/npm-browser-packages/index.html
+
+## 🚴 Usage
+
+### 🐑 Use `cargo generate` to Clone this Template
+
+[Learn more about `cargo generate` here.](https://github.com/ashleygwilliams/cargo-generate)
+
+```
+cargo generate --git https://github.com/rustwasm/wasm-pack-template.git --name my-project
+cd my-project
+```
+
+### 🛠️ Build with `wasm-pack build`
+
+```
+wasm-pack build
+```
+
+### 🔬 Test in Headless Browsers with `wasm-pack test`
+
+```
+wasm-pack test --headless --firefox
+```
+
+### 🎁 Publish to NPM with `wasm-pack publish`
+
+```
+wasm-pack publish
+```
+
+## 🔋 Batteries Included
+
+* [`wasm-bindgen`](https://github.com/rustwasm/wasm-bindgen) for communicating
+  between WebAssembly and JavaScript.
+* [`console_error_panic_hook`](https://github.com/rustwasm/console_error_panic_hook)
+  for logging panic messages to the developer console.
+* `LICENSE-APACHE` and `LICENSE-MIT`: most Rust projects are licensed this way, so these are included for you
+
+## License
+
+Licensed under either of
+
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you, as defined in the Apache-2.0
+license, shall be dual licensed as above, without any additional terms or
+conditions.

--- a/ising-core/src/lib.rs
+++ b/ising-core/src/lib.rs
@@ -1,0 +1,413 @@
+mod utils;
+
+use wasm_bindgen::prelude::*;
+
+// ── Fast xorshift64 RNG ──────────────────────────────────────────────────────
+
+struct Rng(u64);
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Rng(if seed == 0 { 0x123456789abcdef0 } else { seed })
+    }
+
+    #[inline(always)]
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+
+    // Returns f64 in [0, 1)
+    #[inline(always)]
+    fn next_f64(&mut self) -> f64 {
+        (self.next_u64() >> 11) as f64 * (1.0_f64 / (1u64 << 53) as f64)
+    }
+}
+
+// ── Color-sorted bitpacked layout ───────────────────────────────────────────
+//
+// bitIdx = color * M³ + ix + M*iy + M²*iz
+//   where color = (x&1)<<2 | (y&1)<<1 | (z&1),  M = N/2
+//         ix = x/2, iy = y/2, iz = z/2
+//
+// Sites of the same color are mutually non-adjacent (no NN or NNN links),
+// so each color block can be written independently — enabling future
+// lock-free parallel sweeps.
+
+#[inline(always)]
+fn bit_index(x: usize, y: usize, z: usize, n: usize) -> usize {
+    let m = n >> 1;
+    let color = ((x & 1) << 2) | ((y & 1) << 1) | (z & 1);
+    color * m * m * m + (x >> 1) + m * (y >> 1) + m * m * (z >> 1)
+}
+
+#[inline(always)]
+fn wrap(coord: i64, n: usize) -> usize {
+    coord.rem_euclid(n as i64) as usize
+}
+
+#[inline(always)]
+fn get_spin_raw(data: &[u8], x: usize, y: usize, z: usize, n: usize) -> i32 {
+    let idx = bit_index(x, y, z, n);
+    if (data[idx >> 3] >> (idx & 7)) & 1 == 1 { 1 } else { -1 }
+}
+
+#[inline(always)]
+fn get_spin(data: &[u8], x: i64, y: i64, z: i64, n: usize) -> i32 {
+    get_spin_raw(data, wrap(x, n), wrap(y, n), wrap(z, n), n)
+}
+
+#[inline(always)]
+fn flip_bit(data: &mut [u8], idx: usize) {
+    data[idx >> 3] ^= 1u8 << (idx & 7);
+}
+
+fn energy_at(data: &[u8], x: usize, y: usize, z: usize, n: usize, k1: f64, k2: f64, h: f64) -> f64 {
+    let xi = x as i64;
+    let yi = y as i64;
+    let zi = z as i64;
+    let s = get_spin_raw(data, x, y, z, n) as f64;
+
+    let nn = (get_spin(data, xi+1, yi,   zi,   n)
+            + get_spin(data, xi-1, yi,   zi,   n)
+            + get_spin(data, xi,   yi+1, zi,   n)
+            + get_spin(data, xi,   yi-1, zi,   n)
+            + get_spin(data, xi,   yi,   zi+1, n)
+            + get_spin(data, xi,   yi,   zi-1, n)) as f64;
+
+    let nnn = (get_spin(data, xi+1, yi+1, zi,   n)
+             + get_spin(data, xi+1, yi-1, zi,   n)
+             + get_spin(data, xi-1, yi+1, zi,   n)
+             + get_spin(data, xi-1, yi-1, zi,   n)
+             + get_spin(data, xi+1, yi,   zi+1, n)
+             + get_spin(data, xi+1, yi,   zi-1, n)
+             + get_spin(data, xi-1, yi,   zi+1, n)
+             + get_spin(data, xi-1, yi,   zi-1, n)
+             + get_spin(data, xi,   yi+1, zi+1, n)
+             + get_spin(data, xi,   yi+1, zi-1, n)
+             + get_spin(data, xi,   yi-1, zi+1, n)
+             + get_spin(data, xi,   yi-1, zi-1, n)) as f64;
+
+    -k1 * s * nn - k2 * s * nnn - h * s
+}
+
+// ── Public WASM API ──────────────────────────────────────────────────────────
+
+#[wasm_bindgen]
+pub struct SpinLattice {
+    data: Vec<u8>,
+    n: usize,
+    rng: Rng,
+}
+
+#[wasm_bindgen]
+impl SpinLattice {
+    #[wasm_bindgen(constructor)]
+    pub fn new(n: usize, seed: u64) -> SpinLattice {
+        utils::set_panic_hook();
+        let bytes = (n * n * n + 7) / 8;
+        let mut lat = SpinLattice { data: vec![0u8; bytes], n, rng: Rng::new(seed) };
+        lat.randomize();
+        lat
+    }
+
+    pub fn from_bytes(bytes: &[u8], n: usize, seed: u64) -> SpinLattice {
+        utils::set_panic_hook();
+        SpinLattice { data: bytes.to_vec(), n, rng: Rng::new(seed) }
+    }
+
+    pub fn randomize(&mut self) {
+        for byte in self.data.iter_mut() {
+            *byte = self.rng.next_u64() as u8;
+        }
+    }
+
+    pub fn set_ferro(&mut self) {
+        for byte in self.data.iter_mut() { *byte = 0xff; }
+    }
+
+    pub fn set_neel(&mut self) {
+        let n = self.n;
+        for byte in self.data.iter_mut() { *byte = 0; }
+        for z in 0..n {
+            for y in 0..n {
+                for x in 0..n {
+                    if (x + y + z) % 2 == 0 {
+                        let idx = bit_index(x, y, z, n);
+                        self.data[idx >> 3] |= 1u8 << (idx & 7);
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn set_layered(&mut self) {
+        let n = self.n;
+        for byte in self.data.iter_mut() { *byte = 0; }
+        for z in 0..n {
+            for y in 0..n {
+                for x in 0..n {
+                    if x % 2 == 0 {
+                        let idx = bit_index(x, y, z, n);
+                        self.data[idx >> 3] |= 1u8 << (idx & 7);
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn set_diagonal_layered(&mut self) {
+        let n = self.n;
+        for byte in self.data.iter_mut() { *byte = 0; }
+        for z in 0..n {
+            for y in 0..n {
+                for x in 0..n {
+                    if (y + z) % 2 == 0 {
+                        let idx = bit_index(x, y, z, n);
+                        self.data[idx >> 3] |= 1u8 << (idx & 7);
+                    }
+                }
+            }
+        }
+    }
+
+    // 8-sublattice checkerboard sweep.
+    // Colors are processed sequentially; within each color all N³/8 sites are
+    // mutually non-adjacent, so the order within a color does not matter.
+    pub fn sublattice_sweep(&mut self, k1: f64, k2: f64, h: f64) {
+        let n = self.n;
+        let m = n >> 1;
+
+        for color in 0u8..8 {
+            let sx = ((color >> 2) & 1) as usize;
+            let sy = ((color >> 1) & 1) as usize;
+            let sz = (color        & 1) as usize;
+
+            for iz in 0..m {
+                let z = iz * 2 + sz;
+                for iy in 0..m {
+                    let y = iy * 2 + sy;
+                    for ix in 0..m {
+                        let x = ix * 2 + sx;
+
+                        let e_before = energy_at(&self.data, x, y, z, n, k1, k2, h);
+                        let bit_idx = bit_index(x, y, z, n);
+                        flip_bit(&mut self.data, bit_idx);
+                        let e_after = energy_at(&self.data, x, y, z, n, k1, k2, h);
+                        let delta = e_after - e_before;
+
+                        if delta > 0.0 && self.rng.next_f64() > (-delta).exp() {
+                            flip_bit(&mut self.data, bit_idx); // reject
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn magnetization(&self) -> f64 {
+        let n3 = self.n * self.n * self.n;
+        let full_bytes = n3 / 8;
+        let mut sum = 0i32;
+        for i in 0..full_bytes {
+            sum += 2 * self.data[i].count_ones() as i32 - 8;
+        }
+        let rem = n3 % 8;
+        if rem > 0 {
+            let mask = (1u8 << rem) - 1;
+            sum += 2 * (self.data[full_bytes] & mask).count_ones() as i32 - rem as i32;
+        }
+        sum as f64 / n3 as f64
+    }
+
+    pub fn neel_order_param(&self) -> f64 {
+        let n = self.n;
+        let n3 = n * n * n;
+        let mut sum = 0.0f64;
+        for z in 0..n {
+            for y in 0..n {
+                for x in 0..n {
+                    let sign = if (x + y + z) % 2 == 0 { 1.0 } else { -1.0 };
+                    sum += sign * get_spin_raw(&self.data, x, y, z, n) as f64;
+                }
+            }
+        }
+        sum / n3 as f64
+    }
+
+    pub fn get_spin(&self, x: i32, y: i32, z: i32) -> i32 {
+        get_spin(&self.data, x as i64, y as i64, z as i64, self.n)
+    }
+
+    pub fn lattice_size(&self) -> usize { self.n }
+
+    /// Raw bitpacked bytes (color-sorted layout), for copying to JS.
+    pub fn data(&self) -> Vec<u8> { self.data.clone() }
+}
+
+// ── Rust unit tests ──────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_ferro(n: usize) -> Vec<u8> {
+        vec![0xffu8; (n * n * n + 7) / 8]
+    }
+
+    fn make_neel(n: usize) -> Vec<u8> {
+        let mut data = vec![0u8; (n * n * n + 7) / 8];
+        for z in 0..n {
+            for y in 0..n {
+                for x in 0..n {
+                    if (x + y + z) % 2 == 0 {
+                        let idx = bit_index(x, y, z, n);
+                        data[idx >> 3] |= 1u8 << (idx & 7);
+                    }
+                }
+            }
+        }
+        data
+    }
+
+    // bit_index maps all N³ coords to distinct values in [0, N³)
+    #[test]
+    fn bit_index_injective() {
+        for n in [2usize, 4, 8] {
+            let mut seen = std::collections::HashSet::new();
+            for z in 0..n {
+                for y in 0..n {
+                    for x in 0..n {
+                        let idx = bit_index(x, y, z, n);
+                        assert!(idx < n * n * n, "N={n}: idx={idx} out of range at ({x},{y},{z})");
+                        assert!(seen.insert(idx), "N={n}: duplicate idx={idx} at ({x},{y},{z})");
+                    }
+                }
+            }
+        }
+    }
+
+    // get_spin round-trip via flip
+    #[test]
+    fn flip_roundtrip() {
+        let n = 4;
+        let mut data = make_ferro(n);
+        flip_bit(&mut data, bit_index(2, 2, 2, n));
+        assert_eq!(get_spin_raw(&data, 2, 2, 2, n), -1);
+        flip_bit(&mut data, bit_index(2, 2, 2, n));
+        assert_eq!(get_spin_raw(&data, 2, 2, 2, n), 1);
+    }
+
+    // Ferromagnetic state: all spins +1
+    #[test]
+    fn ferro_all_up() {
+        let n = 4;
+        let data = make_ferro(n);
+        for z in 0..n {
+            for y in 0..n {
+                for x in 0..n {
+                    assert_eq!(get_spin_raw(&data, x, y, z, n), 1, "({x},{y},{z})");
+                }
+            }
+        }
+    }
+
+    // Magnetization of all-up lattice = 1.0
+    #[test]
+    fn magnetization_ferro() {
+        let n = 4;
+        let data = make_ferro(n);
+        let n3 = n * n * n;
+        let sum: i32 = (0..n3 / 8).map(|i| 2 * data[i].count_ones() as i32 - 8).sum();
+        let mag = sum as f64 / n3 as f64;
+        assert!((mag - 1.0).abs() < 1e-10, "mag = {mag}");
+    }
+
+    // Neel state: spin at (x,y,z) = (-1)^(x+y+z)
+    #[test]
+    fn neel_spins_correct() {
+        let n = 4;
+        let data = make_neel(n);
+        for z in 0..n {
+            for y in 0..n {
+                for x in 0..n {
+                    let expected = if (x + y + z) % 2 == 0 { 1 } else { -1 };
+                    assert_eq!(get_spin_raw(&data, x, y, z, n), expected, "({x},{y},{z})");
+                }
+            }
+        }
+    }
+
+    // energy_at for all-up: local energy = -k1 * 6, flipping gives +k1 * 6, ΔE = 12k1
+    #[test]
+    fn energy_flip_nn_only() {
+        let n = 4;
+        let k1 = 1.0;
+        let data = make_ferro(n);
+
+        let e_before = energy_at(&data, 2, 2, 2, n, k1, 0.0, 0.0);
+        assert!((e_before + 6.0).abs() < 1e-10, "e_before={e_before}");
+
+        let mut flipped = data.clone();
+        flip_bit(&mut flipped, bit_index(2, 2, 2, n));
+        let e_after = energy_at(&flipped, 2, 2, 2, n, k1, 0.0, 0.0);
+        assert!((e_after - 6.0).abs() < 1e-10, "e_after={e_after}");
+        assert!((e_after - e_before - 12.0).abs() < 1e-10, "ΔE={}", e_after - e_before);
+    }
+
+    // energy_at with NNN: ΔE = 12k1 + 24k2
+    #[test]
+    fn energy_flip_with_nnn() {
+        let n = 4;
+        let k1 = 1.0;
+        let k2 = 1.0;
+        let data = make_ferro(n);
+        let e_before = energy_at(&data, 2, 2, 2, n, k1, k2, 0.0);
+        let mut flipped = data.clone();
+        flip_bit(&mut flipped, bit_index(2, 2, 2, n));
+        let e_after = energy_at(&flipped, 2, 2, 2, n, k1, k2, 0.0);
+        assert!(
+            (e_after - e_before - (12.0 * k1 + 24.0 * k2)).abs() < 1e-10,
+            "ΔE={} expected={}", e_after - e_before, 12.0 * k1 + 24.0 * k2
+        );
+    }
+
+    // Periodic boundary: get_spin wraps correctly
+    #[test]
+    fn periodic_boundary() {
+        let n = 4;
+        let mut data = make_ferro(n);
+        flip_bit(&mut data, bit_index(0, 0, 0, n)); // (0,0,0) → -1
+        flip_bit(&mut data, bit_index(3, 0, 0, n)); // (3,0,0) → -1
+        // x=4 wraps to 0, x=-4 wraps to 0
+        assert_eq!(get_spin(&data,  4, 0, 0, n), -1, "4 mod 4 = 0");
+        assert_eq!(get_spin(&data, -4, 0, 0, n), -1, "-4 mod 4 = 0");
+        // x=-1 wraps to 3
+        assert_eq!(get_spin(&data, -1, 0, 0, n), -1, "-1 mod 4 = 3");
+        // unflipped site still +1
+        assert_eq!(get_spin(&data,  1, 0, 0, n),  1, "(1,0,0) untouched");
+    }
+
+    // Neel order param = 1 for perfect Neel state
+    #[test]
+    fn neel_order_param_perfect() {
+        let n = 4;
+        let data = make_neel(n);
+        let n3 = n * n * n;
+        let mut sum = 0.0f64;
+        for z in 0..n {
+            for y in 0..n {
+                for x in 0..n {
+                    let sign = if (x + y + z) % 2 == 0 { 1.0 } else { -1.0 };
+                    sum += sign * get_spin_raw(&data, x, y, z, n) as f64;
+                }
+            }
+        }
+        let op = (sum / n3 as f64).abs();
+        assert!((op - 1.0).abs() < 1e-10, "neel_op={op}");
+    }
+}

--- a/ising-core/src/utils.rs
+++ b/ising-core/src/utils.rs
@@ -1,0 +1,10 @@
+pub fn set_panic_hook() {
+    // When the `console_error_panic_hook` feature is enabled, we can call the
+    // `set_panic_hook` function at least once during initialization, and then
+    // we will get better error messages if our code ever panics.
+    //
+    // For more details see
+    // https://github.com/rustwasm/console_error_panic_hook#readme
+    #[cfg(feature = "console_error_panic_hook")]
+    console_error_panic_hook::set_once();
+}

--- a/ising-core/tests/web.rs
+++ b/ising-core/tests/web.rs
@@ -1,0 +1,13 @@
+//! Test suite for the Web and headless browsers.
+
+#![cfg(target_arch = "wasm32")]
+
+extern crate wasm_bindgen_test;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn pass() {
+    assert_eq!(1 + 1, 2);
+}

--- a/src/hooks/useSimulation.ts
+++ b/src/hooks/useSimulation.ts
@@ -3,6 +3,8 @@ import { useEffect, useRef } from "react";
 import { SpinLattice } from "@/services/spin-lattice";
 import { simulateMetropoliseSweepLattice } from "@/services/metropolis";
 import { renderSliceToImageData, drawTiledOnCanvas, SliceAxis } from "@/services/canvas-lattice";
+import { loadWasm } from "@/services/wasm-loader";
+import type { WasmLattice } from "@/services/wasm-loader";
 
 const FRAMES_PER_SWEEP = 6; // one full lattice sweep every 6 frames (~10/s at 60 fps)
 const PIXELS_PER_SPIN = 16;
@@ -78,6 +80,7 @@ export function useSimulation({
   onStats: (stats: SimStats) => void;
 }) {
   const latticeRef = useRef<SpinLattice>(new SpinLattice(initialSpins));
+  const wasmRef = useRef<WasmLattice | null>(null);
   const paramsRef = useRef({ betaJ, betaJ2, betaH, tStar, sliceAxis, sliceIndex });
   const runningRef = useRef(running);
   const onStatsRef = useRef(onStats);
@@ -93,12 +96,22 @@ export function useSimulation({
   onStatsRef.current = onStats;
 
   useEffect(() => {
-    latticeRef.current = new SpinLattice(initialSpins);
+    const newLat = new SpinLattice(initialSpins);
+    latticeRef.current = newLat;
     sweepsRef.current = 0;
     skPathRef.current = null;
     skLastComputedSweepRef.current = -1;
     stripeRef.current = 0;
-    skPathDefRef.current = buildSkPath(latticeRef.current.latticeSize);
+    skPathDefRef.current = buildSkPath(newLat.latticeSize);
+
+    // (Re-)initialize WASM lattice from the new JS bytes.
+    // loadWasm() is cached after the first call.
+    loadWasm().then(({ SpinLattice: W }) => {
+      const bytes = new Uint8Array(newLat);
+      const seed = BigInt(Math.floor(Math.random() * Number.MAX_SAFE_INTEGER));
+      wasmRef.current?.free();
+      wasmRef.current = W.from_bytes(bytes, newLat.latticeSize, seed);
+    });
   }, [initialSpins]);
 
   // Resize canvas to fill viewport
@@ -122,12 +135,16 @@ export function useSimulation({
 
       frameRef.current++;
       if (runningRef.current && frameRef.current % FRAMES_PER_SWEEP === 0) {
-        latticeRef.current = simulateMetropoliseSweepLattice(
-          latticeRef.current,
-          betaJ,
-          betaJ2,
-          betaH
-        );
+        const wl = wasmRef.current;
+        if (wl) {
+          wl.sublattice_sweep(betaJ, betaJ2, betaH);
+          latticeRef.current.set(wl.data()); // sync bytes back to JS lattice
+        } else {
+          // fallback to JS until WASM is loaded
+          latticeRef.current = simulateMetropoliseSweepLattice(
+            latticeRef.current, betaJ, betaJ2, betaH
+          );
+        }
         sweepsRef.current++;
       }
 

--- a/src/services/__tests__/spin-lattice.test.ts
+++ b/src/services/__tests__/spin-lattice.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, test } from "vitest";
 import { SpinLattice } from "../spin-lattice";
 
 // Helpers -----------------------------------------------------------------
@@ -172,5 +172,92 @@ describe("SpinLattice – betaEnergy", () => {
   it("betaJ = 0 and betaH = 0 gives zero energy regardless of spin config", () => {
     expect(uniform(4, 1).betaEnergy(0, 0, 0)).toBeCloseTo(0);
     expect(uniform(4, -1).betaEnergy(0, 0, 0)).toBeCloseTo(0);
+  });
+
+  it("NNN energy: all-up lattice with betaJ2 = 1", () => {
+    // 12 NNN bonds per site, each = +1; N³ × 12/2 bonds total; E = -betaJ2 × bonds
+    const N = 2;
+    const lat = uniform(N, 1);
+    expect(lat.betaEnergy(0, 1, 0)).toBeCloseTo(-(N ** 3) * 6);
+  });
+});
+
+// -------------------------------------------------------------------------
+
+describe("SpinLattice – bitIndex layout", () => {
+  test.each([2, 4, 8])("N=%i: all N³ coords map to distinct indices in [0, N³)", (N) => {
+    const lat = new SpinLattice(N);
+    const seen = new Set<number>();
+    for (let z = 0; z < N; z++)
+      for (let y = 0; y < N; y++)
+        for (let x = 0; x < N; x++) {
+          const idx = lat.bitIndex({ x, y, z });
+          expect(idx).toBeGreaterThanOrEqual(0);
+          expect(idx).toBeLessThan(N ** 3);
+          expect(seen.has(idx)).toBe(false);
+          seen.add(idx);
+        }
+    expect(seen.size).toBe(N ** 3);
+  });
+
+  it("periodic wrapping resolves to the same index as the canonical coord", () => {
+    const lat = new SpinLattice(4);
+    expect(lat.bitIndex({ x: 4, y: 0, z: 0 })).toBe(lat.bitIndex({ x: 0, y: 0, z: 0 }));
+    expect(lat.bitIndex({ x: -1, y: 0, z: 0 })).toBe(lat.bitIndex({ x: 3, y: 0, z: 0 }));
+    expect(lat.bitIndex({ x: 0, y: 5, z: -2 })).toBe(lat.bitIndex({ x: 0, y: 1, z: 2 }));
+  });
+});
+
+// -------------------------------------------------------------------------
+
+describe("SpinLattice – order parameters", () => {
+  it("neelOrderParam: perfect Néel state returns +1 or −1", () => {
+    const lat = SpinLattice.createNeel(4);
+    expect(Math.abs(lat.neelOrderParam())).toBeCloseTo(1);
+  });
+
+  it("neelOrderParam: ferromagnetic state returns 0", () => {
+    expect(SpinLattice.createFerro(4).neelOrderParam()).toBeCloseTo(0);
+  });
+
+  it("stripeOrderParam: perfect layered state (along x) returns 1", () => {
+    expect(SpinLattice.createLayered(4).stripeOrderParam()).toBeCloseTo(1);
+  });
+
+  it("stripeOrderParam: diagonal-layered state returns 1", () => {
+    expect(SpinLattice.createDiagonalLayered(4).stripeOrderParam()).toBeCloseTo(1);
+  });
+
+  it("stripeOrderParam: ferromagnetic state returns 0", () => {
+    expect(SpinLattice.createFerro(4).stripeOrderParam()).toBeCloseTo(0);
+  });
+});
+
+// -------------------------------------------------------------------------
+
+describe("SpinLattice – energyAt", () => {
+  it("all-up lattice: flipping any site raises energy by 12 betaJ (6 NN each contributing 2)", () => {
+    const N = 4;
+    const betaJ = 1;
+    const lat = uniform(N, 1);
+    const coord = { x: 2, y: 2, z: 2 };
+    const eBefore = lat.energyAt(coord, betaJ, 0, 0);
+    lat.flipSpin(coord);
+    const eAfter = lat.energyAt(coord, betaJ, 0, 0);
+    // flipped site is -1 surrounded by 6 +1 neighbours → local E goes from -6 to +6
+    expect(eAfter - eBefore).toBeCloseTo(12);
+  });
+
+  it("all-up with NNN: flipping raises energy by 12·betaJ + 24·betaJ2", () => {
+    const N = 4;
+    const betaJ = 1;
+    const betaJ2 = 1;
+    const lat = uniform(N, 1);
+    const coord = { x: 2, y: 2, z: 2 };
+    const eBefore = lat.energyAt(coord, betaJ, betaJ2, 0);
+    lat.flipSpin(coord);
+    const eAfter = lat.energyAt(coord, betaJ, betaJ2, 0);
+    // s flips +1→-1; ΔE = 2·betaJ·nnSum + 2·betaJ2·nnnSum = 2·1·6 + 2·1·12 = 36
+    expect(eAfter - eBefore).toBeCloseTo(12 * betaJ + 24 * betaJ2);
   });
 });

--- a/src/services/wasm-loader.ts
+++ b/src/services/wasm-loader.ts
@@ -4,7 +4,7 @@ export type { SpinLattice as WasmLattice };
 // Inline the subset of the generated types we need at runtime,
 // so we don't have to bundle the wasm glue through webpack.
 interface WasmModule {
-  default(wasmUrl: string): Promise<unknown>;
+  default(opts: { module_or_path: string }): Promise<unknown>;
   SpinLattice: {
     new(n: number, seed: bigint): SpinLattice;
     from_bytes(bytes: Uint8Array, n: number, seed: bigint): SpinLattice;
@@ -22,8 +22,8 @@ export function loadWasm(): Promise<WasmModule> {
     const m = await import(
       /* webpackIgnore: true */ "/wasm/ising_core.js" as string
     ) as WasmModule;
-    await m.default("/wasm/ising_core_bg.wasm");
+    await m.default({ module_or_path: "/wasm/ising_core_bg.wasm" });
     return m;
-  })();
+  })().catch((e) => { console.error("[wasm] load failed:", e); throw e; });
   return ready;
 }

--- a/src/services/wasm-loader.ts
+++ b/src/services/wasm-loader.ts
@@ -1,0 +1,29 @@
+import type { SpinLattice } from "../../public/wasm/ising_core";
+export type { SpinLattice as WasmLattice };
+
+// Inline the subset of the generated types we need at runtime,
+// so we don't have to bundle the wasm glue through webpack.
+interface WasmModule {
+  default(wasmUrl: string): Promise<unknown>;
+  SpinLattice: {
+    new(n: number, seed: bigint): SpinLattice;
+    from_bytes(bytes: Uint8Array, n: number, seed: bigint): SpinLattice;
+  };
+}
+
+let ready: Promise<WasmModule> | null = null;
+
+// Loads the WASM module once; subsequent calls return the cached promise.
+// The JS glue is loaded as a native ES module from /wasm/ (public/),
+// bypassing webpack so the .wasm binary fetch resolves correctly at runtime.
+export function loadWasm(): Promise<WasmModule> {
+  if (ready) return ready;
+  ready = (async () => {
+    const m = await import(
+      /* webpackIgnore: true */ "/wasm/ising_core.js" as string
+    ) as WasmModule;
+    await m.default("/wasm/ising_core_bg.wasm");
+    return m;
+  })();
+  return ready;
+}


### PR DESCRIPTION
## Summary

- **色ソート済みbitpackedレイアウト** (`bitIndex` を `color * M³ + ix + M*iy + M²*iz` に変更)。同色サイトのブロックが連続するため、将来の色内並列書き込みがロックフリーで可能になる
- **Rust/WASM クレート `ising-core`** を追加。8サブラティス チェッカーボード Metropolis sweep・xorshift64 RNG・magnetization・neel_order_param を実装
- **JS `useSimulation` に統合**。WASM ロード後は `sublattice_sweep` に差し替え、bytes を JS `SpinLattice` に `.set()` 同期して描画・計測はそのまま動作。ロード前は JS fallback
- Rust ユニットテスト 9件・TS テスト 55件すべてパス

## Test plan

- [ ] `cargo test` (ising-core/) がパスする
- [ ] `pnpm test` がパスする
- [ ] `pnpm dev` でブラウザ起動、コンソールにエラーなし
- [ ] Network タブで `ising_core.js` / `ising_core_bg.wasm` が 200 で返る

🤖 Generated with [Claude Code](https://claude.com/claude-code)