### PR TITLE
feat: energy distribution histogram

### DIFF
--- a/src/components/energy-histogram-panel.tsx
+++ b/src/components/energy-histogram-panel.tsx
@@ -1,0 +1,203 @@
+"use client";
+import { useMemo } from "react";
+
+const PANEL_W = 220;
+const CHART_H = 80;
+const PAD_L = 28;
+const PAD_R = 8;
+const PAD_T = 8;
+const PAD_B = 24;
+const CHART_W = PANEL_W - PAD_L - PAD_R;
+const N_BINS = 20;
+
+function buildHistogram(samples: Float32Array): {
+  bins: number[];
+  edges: number[];
+  mean: number;
+  std: number;
+} {
+  let sum = 0;
+  let min = Infinity;
+  let max = -Infinity;
+  for (let i = 0; i < samples.length; i++) {
+    sum += samples[i];
+    if (samples[i] < min) min = samples[i];
+    if (samples[i] > max) max = samples[i];
+  }
+  const mean = sum / samples.length;
+
+  let variance = 0;
+  for (let i = 0; i < samples.length; i++) {
+    variance += (samples[i] - mean) ** 2;
+  }
+  const std = Math.sqrt(variance / samples.length);
+
+  // Widen range slightly to avoid clipping
+  const pad = std * 0.5 || Math.abs(max - min) * 0.1 || 0.1;
+  const lo = min - pad;
+  const hi = max + pad;
+  const binWidth = (hi - lo) / N_BINS;
+
+  const bins = new Array<number>(N_BINS).fill(0);
+  for (let i = 0; i < samples.length; i++) {
+    const b = Math.min(Math.floor((samples[i] - lo) / binWidth), N_BINS - 1);
+    bins[b]++;
+  }
+
+  const edges = Array.from({ length: N_BINS + 1 }, (_, i) => lo + i * binWidth);
+  return { bins, edges, mean, std };
+}
+
+export default function EnergyHistogramPanel({
+  energySamples,
+}: {
+  energySamples: Float32Array | null;
+}) {
+  const viewH = CHART_H + PAD_T + PAD_B;
+  const viewW = PANEL_W;
+
+  const hist = useMemo(
+    () => (energySamples ? buildHistogram(energySamples) : null),
+    [energySamples]
+  );
+
+  const bars = useMemo(() => {
+    if (!hist) return null;
+    const { bins, edges } = hist;
+    const maxCount = Math.max(...bins, 1);
+    return bins.map((count, i) => {
+      const x0 = PAD_L + ((edges[i] - edges[0]) / (edges[N_BINS] - edges[0])) * CHART_W;
+      const x1 = PAD_L + ((edges[i + 1] - edges[0]) / (edges[N_BINS] - edges[0])) * CHART_W;
+      const barH = (count / maxCount) * CHART_H;
+      return (
+        <rect
+          key={i}
+          x={x0 + 0.5}
+          y={PAD_T + CHART_H - barH}
+          width={Math.max(x1 - x0 - 1, 0.5)}
+          height={barH}
+          fill="#f97316"
+          opacity={0.8}
+        />
+      );
+    });
+  }, [hist]);
+
+  // Gaussian overlay: P(E) ∝ exp(-(E-μ)²/(2σ²)), scaled to histogram height
+  // Gaussian peak = 1.0 → y = PAD_T, matching the tallest bar at maxCount height.
+  const gaussianPath = useMemo(() => {
+    if (!hist || hist.std < 1e-10) return null;
+    const { edges, mean, std } = hist;
+    const lo = edges[0];
+    const hi = edges[N_BINS];
+    const nPts = 80;
+    const pts: string[] = [];
+    for (let i = 0; i <= nPts; i++) {
+      const e = lo + (i / nPts) * (hi - lo);
+      const p = Math.exp(-((e - mean) ** 2) / (2 * std ** 2));
+      const x = PAD_L + ((e - lo) / (hi - lo)) * CHART_W;
+      const y = PAD_T + CHART_H * (1 - p);
+      pts.push(`${x.toFixed(1)},${y.toFixed(1)}`);
+    }
+    return pts.join(" ");
+  }, [hist]);
+
+  const xLabels = useMemo(() => {
+    if (!hist) return null;
+    const lo = hist.edges[0];
+    const hi = hist.edges[N_BINS];
+    return [lo, (lo + hi) / 2, hi].map((v) => ({
+      x: PAD_L + ((v - lo) / (hi - lo)) * CHART_W,
+      label: v.toFixed(1),
+    }));
+  }, [hist]);
+
+  return (
+    <div>
+      <svg
+        width={viewW}
+        height={viewH}
+        className="block"
+        style={{ fontFamily: "inherit" }}
+      >
+        {/* Axes */}
+        <line
+          x1={PAD_L} y1={PAD_T}
+          x2={PAD_L} y2={PAD_T + CHART_H}
+          stroke="#6b7280" strokeWidth={1}
+        />
+        <line
+          x1={PAD_L} y1={PAD_T + CHART_H}
+          x2={PAD_L + CHART_W} y2={PAD_T + CHART_H}
+          stroke="#6b7280" strokeWidth={1}
+        />
+
+        {/* y-axis label */}
+        <text
+          x={PAD_L - 4} y={PAD_T + 4}
+          textAnchor="end" fontSize={8} fill="#9ca3af"
+        >
+          freq
+        </text>
+
+        {/* x-axis tick labels */}
+        {xLabels?.map(({ x, label }) => (
+          <text
+            key={label}
+            x={x} y={PAD_T + CHART_H + 12}
+            textAnchor="middle" fontSize={8} fill="#9ca3af"
+          >
+            {label}
+          </text>
+        ))}
+
+        {/* x-axis label */}
+        <text
+          x={PAD_L + CHART_W + 4} y={PAD_T + CHART_H + 4}
+          textAnchor="start" fontSize={9} fill="#9ca3af" fontStyle="italic"
+        >
+          E
+        </text>
+
+        {bars ?? (
+          <text
+            x={PAD_L + CHART_W / 2} y={PAD_T + CHART_H / 2}
+            textAnchor="middle" fontSize={9} fill="#6b7280"
+          >
+            running…
+          </text>
+        )}
+
+        {/* Gaussian overlay */}
+        {gaussianPath && (
+          <polyline
+            points={gaussianPath}
+            fill="none"
+            stroke="#60a5fa"
+            strokeWidth={1.5}
+            strokeLinejoin="round"
+            opacity={0.85}
+          />
+        )}
+
+        {/* Legend */}
+        {hist && (
+          <text
+            x={PAD_L + CHART_W} y={PAD_T + 9}
+            textAnchor="end" fontSize={7.5} fill="#60a5fa"
+          >
+            Gaussian fit
+          </text>
+        )}
+      </svg>
+
+      {hist && (
+        <div className="text-xs text-gray-400 mt-0.5 leading-tight">
+          <span>μ = {hist.mean.toFixed(3)}</span>
+          <span className="ml-2">σ = {hist.std.toFixed(3)}</span>
+          <span className="ml-2">n = {energySamples!.length}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/energy-histogram-panel.tsx
+++ b/src/components/energy-histogram-panel.tsx
@@ -10,12 +10,7 @@ const PAD_B = 24;
 const CHART_W = PANEL_W - PAD_L - PAD_R;
 const N_BINS = 20;
 
-function buildHistogram(samples: Float32Array): {
-  bins: number[];
-  edges: number[];
-  mean: number;
-  std: number;
-} {
+function buildHistogram(samples: Float32Array) {
   let sum = 0;
   let min = Infinity;
   let max = -Infinity;
@@ -27,12 +22,9 @@ function buildHistogram(samples: Float32Array): {
   const mean = sum / samples.length;
 
   let variance = 0;
-  for (let i = 0; i < samples.length; i++) {
-    variance += (samples[i] - mean) ** 2;
-  }
+  for (let i = 0; i < samples.length; i++) variance += (samples[i] - mean) ** 2;
   const std = Math.sqrt(variance / samples.length);
 
-  // Widen range slightly to avoid clipping
   const pad = std * 0.5 || Math.abs(max - min) * 0.1 || 0.1;
   const lo = min - pad;
   const hi = max + pad;
@@ -40,25 +32,31 @@ function buildHistogram(samples: Float32Array): {
 
   const bins = new Array<number>(N_BINS).fill(0);
   for (let i = 0; i < samples.length; i++) {
-    const b = Math.min(Math.floor((samples[i] - lo) / binWidth), N_BINS - 1);
-    bins[b]++;
+    bins[Math.min(Math.floor((samples[i] - lo) / binWidth), N_BINS - 1)]++;
   }
 
   const edges = Array.from({ length: N_BINS + 1 }, (_, i) => lo + i * binWidth);
   return { bins, edges, mean, std };
 }
 
-export default function EnergyHistogramPanel({
-  energySamples,
+export default function HistogramPanel({
+  samples,
+  samplesFilled,
+  xLabel,
+  barColor,
+  showGaussian = false,
 }: {
-  energySamples: Float32Array | null;
+  samples: Float32Array | null;
+  samplesFilled: number;
+  xLabel: string;
+  barColor: string;
+  showGaussian?: boolean;
 }) {
   const viewH = CHART_H + PAD_T + PAD_B;
-  const viewW = PANEL_W;
 
   const hist = useMemo(
-    () => (energySamples ? buildHistogram(energySamples) : null),
-    [energySamples]
+    () => (samples ? buildHistogram(samples) : null),
+    [samples]
   );
 
   const bars = useMemo(() => {
@@ -76,31 +74,30 @@ export default function EnergyHistogramPanel({
           y={PAD_T + CHART_H - barH}
           width={Math.max(x1 - x0 - 1, 0.5)}
           height={barH}
-          fill="#f97316"
+          fill={barColor}
           opacity={0.8}
         />
       );
     });
-  }, [hist]);
+  }, [hist, barColor]);
 
-  // Gaussian overlay: P(E) ∝ exp(-(E-μ)²/(2σ²)), scaled to histogram height
-  // Gaussian peak = 1.0 → y = PAD_T, matching the tallest bar at maxCount height.
+  // Gaussian overlay: peak = 1.0 maps to y=PAD_T (top of chart), matching tallest bar
   const gaussianPath = useMemo(() => {
-    if (!hist || hist.std < 1e-10) return null;
+    if (!showGaussian || !hist || hist.std < 1e-10) return null;
     const { edges, mean, std } = hist;
     const lo = edges[0];
     const hi = edges[N_BINS];
-    const nPts = 80;
     const pts: string[] = [];
-    for (let i = 0; i <= nPts; i++) {
-      const e = lo + (i / nPts) * (hi - lo);
+    for (let i = 0; i <= 80; i++) {
+      const e = lo + (i / 80) * (hi - lo);
       const p = Math.exp(-((e - mean) ** 2) / (2 * std ** 2));
-      const x = PAD_L + ((e - lo) / (hi - lo)) * CHART_W;
-      const y = PAD_T + CHART_H * (1 - p);
-      pts.push(`${x.toFixed(1)},${y.toFixed(1)}`);
+      pts.push(
+        `${(PAD_L + ((e - lo) / (hi - lo)) * CHART_W).toFixed(1)},` +
+        `${(PAD_T + CHART_H * (1 - p)).toFixed(1)}`
+      );
     }
     return pts.join(" ");
-  }, [hist]);
+  }, [hist, showGaussian]);
 
   const xLabels = useMemo(() => {
     if (!hist) return null;
@@ -108,84 +105,39 @@ export default function EnergyHistogramPanel({
     const hi = hist.edges[N_BINS];
     return [lo, (lo + hi) / 2, hi].map((v) => ({
       x: PAD_L + ((v - lo) / (hi - lo)) * CHART_W,
-      label: v.toFixed(1),
+      label: v.toFixed(2),
     }));
   }, [hist]);
 
   return (
     <div>
-      <svg
-        width={viewW}
-        height={viewH}
-        className="block"
-        style={{ fontFamily: "inherit" }}
-      >
-        {/* Axes */}
-        <line
-          x1={PAD_L} y1={PAD_T}
-          x2={PAD_L} y2={PAD_T + CHART_H}
-          stroke="#6b7280" strokeWidth={1}
-        />
-        <line
-          x1={PAD_L} y1={PAD_T + CHART_H}
-          x2={PAD_L + CHART_W} y2={PAD_T + CHART_H}
-          stroke="#6b7280" strokeWidth={1}
-        />
+      <svg width={PANEL_W} height={viewH} className="block" style={{ fontFamily: "inherit" }}>
+        <line x1={PAD_L} y1={PAD_T} x2={PAD_L} y2={PAD_T + CHART_H} stroke="#6b7280" strokeWidth={1} />
+        <line x1={PAD_L} y1={PAD_T + CHART_H} x2={PAD_L + CHART_W} y2={PAD_T + CHART_H} stroke="#6b7280" strokeWidth={1} />
 
-        {/* y-axis label */}
-        <text
-          x={PAD_L - 4} y={PAD_T + 4}
-          textAnchor="end" fontSize={8} fill="#9ca3af"
-        >
-          freq
-        </text>
+        <text x={PAD_L - 4} y={PAD_T + 4} textAnchor="end" fontSize={8} fill="#9ca3af">freq</text>
 
-        {/* x-axis tick labels */}
         {xLabels?.map(({ x, label }) => (
-          <text
-            key={label}
-            x={x} y={PAD_T + CHART_H + 12}
-            textAnchor="middle" fontSize={8} fill="#9ca3af"
-          >
+          <text key={label} x={x} y={PAD_T + CHART_H + 12} textAnchor="middle" fontSize={8} fill="#9ca3af">
             {label}
           </text>
         ))}
 
-        {/* x-axis label */}
-        <text
-          x={PAD_L + CHART_W + 4} y={PAD_T + CHART_H + 4}
-          textAnchor="start" fontSize={9} fill="#9ca3af" fontStyle="italic"
-        >
-          E
+        <text x={PAD_L + CHART_W + 4} y={PAD_T + CHART_H + 4} textAnchor="start" fontSize={9} fill="#9ca3af" fontStyle="italic">
+          {xLabel}
         </text>
 
         {bars ?? (
-          <text
-            x={PAD_L + CHART_W / 2} y={PAD_T + CHART_H / 2}
-            textAnchor="middle" fontSize={9} fill="#6b7280"
-          >
-            running…
+          <text x={PAD_L + CHART_W / 2} y={PAD_T + CHART_H / 2} textAnchor="middle" fontSize={9} fill="#6b7280">
+            {samplesFilled > 0 ? `collecting… ${samplesFilled}/20` : "start simulation"}
           </text>
         )}
 
-        {/* Gaussian overlay */}
         {gaussianPath && (
-          <polyline
-            points={gaussianPath}
-            fill="none"
-            stroke="#60a5fa"
-            strokeWidth={1.5}
-            strokeLinejoin="round"
-            opacity={0.85}
-          />
+          <polyline points={gaussianPath} fill="none" stroke="#60a5fa" strokeWidth={1.5} strokeLinejoin="round" opacity={0.85} />
         )}
-
-        {/* Legend */}
-        {hist && (
-          <text
-            x={PAD_L + CHART_W} y={PAD_T + 9}
-            textAnchor="end" fontSize={7.5} fill="#60a5fa"
-          >
+        {showGaussian && hist && (
+          <text x={PAD_L + CHART_W} y={PAD_T + 9} textAnchor="end" fontSize={7.5} fill="#60a5fa">
             Gaussian fit
           </text>
         )}
@@ -193,9 +145,9 @@ export default function EnergyHistogramPanel({
 
       {hist && (
         <div className="text-xs text-gray-400 mt-0.5 leading-tight">
-          <span>μ = {hist.mean.toFixed(3)}</span>
-          <span className="ml-2">σ = {hist.std.toFixed(3)}</span>
-          <span className="ml-2">n = {energySamples!.length}</span>
+          <span>μ={hist.mean.toFixed(3)}</span>
+          <span className="ml-2">σ={hist.std.toFixed(3)}</span>
+          <span className="ml-2">n={samples!.length}</span>
         </div>
       )}
     </div>

--- a/src/components/ising-page.tsx
+++ b/src/components/ising-page.tsx
@@ -6,7 +6,7 @@ import { T_STAR_CRITICAL } from "@/constants";
 import ConfigSection from "./config-section";
 import StatisticalInfo from "./statistical-info";
 import StructureFactorPanel from "./structure-factor-panel";
-import EnergyHistogramPanel from "./energy-histogram-panel";
+import HistogramPanel from "./energy-histogram-panel";
 import PhaseDiagramPanel from "./phase-diagram-panel";
 import { SpinLattice } from "@/services/spin-lattice";
 import type { SliceAxis } from "@/services/canvas-lattice";
@@ -81,7 +81,8 @@ export function IsingPage({
   const [paramsOpen, setParamsOpen] = useState(true);
   const [statsOpen, setStatsOpen] = useState(true);
   const [skOpen, setSkOpen] = useState(true);
-  const [histOpen, setHistOpen] = useState(true);
+  const [eHistOpen, setEHistOpen] = useState(true);
+  const [mHistOpen, setMHistOpen] = useState(true);
   const [phaseOpen, setPhaseOpen] = useState(true);
 
   const K1 = jSign / tStar;
@@ -113,6 +114,8 @@ export function IsingPage({
       stripeOrderParam: 0,
       skPath: null,
       energySamples: null,
+      magnetizationSamples: null,
+      histSamplesFilled: 0,
     }),
     [initialLattice, initialBetaJ, initialBetaH]
   );
@@ -219,11 +222,30 @@ export function IsingPage({
       </AccordionSection>
       <AccordionSection
         title="Energy Distribution"
-        tip="Histogram of E/site samples. Blue curve: Gaussian fit (Boltzmann distribution in thermodynamic limit)."
-        open={histOpen}
-        onToggle={() => setHistOpen((o) => !o)}
+        tip="E/site = (1/N³)ΣEᵢ sampled each sweep. Gaussian by CLT."
+        open={eHistOpen}
+        onToggle={() => setEHistOpen((o) => !o)}
       >
-        <EnergyHistogramPanel energySamples={stats.energySamples} />
+        <HistogramPanel
+          samples={stats.energySamples}
+          samplesFilled={stats.histSamplesFilled}
+          xLabel="E"
+          barColor="#f97316"
+          showGaussian={true}
+        />
+      </AccordionSection>
+      <AccordionSection
+        title="Magnetization Distribution"
+        tip="M = (1/N³)Σsᵢ sampled each sweep. Bimodal below Tc shows ergodicity is broken for large N."
+        open={mHistOpen}
+        onToggle={() => setMHistOpen((o) => !o)}
+      >
+        <HistogramPanel
+          samples={stats.magnetizationSamples}
+          samplesFilled={stats.histSamplesFilled}
+          xLabel="M"
+          barColor="#34d399"
+        />
       </AccordionSection>
     </div>
   );

--- a/src/components/ising-page.tsx
+++ b/src/components/ising-page.tsx
@@ -6,6 +6,7 @@ import { T_STAR_CRITICAL } from "@/constants";
 import ConfigSection from "./config-section";
 import StatisticalInfo from "./statistical-info";
 import StructureFactorPanel from "./structure-factor-panel";
+import EnergyHistogramPanel from "./energy-histogram-panel";
 import PhaseDiagramPanel from "./phase-diagram-panel";
 import { SpinLattice } from "@/services/spin-lattice";
 import type { SliceAxis } from "@/services/canvas-lattice";
@@ -80,6 +81,7 @@ export function IsingPage({
   const [paramsOpen, setParamsOpen] = useState(true);
   const [statsOpen, setStatsOpen] = useState(true);
   const [skOpen, setSkOpen] = useState(true);
+  const [histOpen, setHistOpen] = useState(true);
   const [phaseOpen, setPhaseOpen] = useState(true);
 
   const K1 = jSign / tStar;
@@ -110,6 +112,7 @@ export function IsingPage({
       neelOrderParam: initialLattice.neelOrderParam(),
       stripeOrderParam: 0,
       skPath: null,
+      energySamples: null,
     }),
     [initialLattice, initialBetaJ, initialBetaH]
   );
@@ -213,6 +216,14 @@ export function IsingPage({
         onToggle={() => setSkOpen((o) => !o)}
       >
         <StructureFactorPanel skPath={stats.skPath} latticeSize={latticeSize} />
+      </AccordionSection>
+      <AccordionSection
+        title="Energy Distribution"
+        tip="Histogram of E/site samples. Blue curve: Gaussian fit (Boltzmann distribution in thermodynamic limit)."
+        open={histOpen}
+        onToggle={() => setHistOpen((o) => !o)}
+      >
+        <EnergyHistogramPanel energySamples={stats.energySamples} />
       </AccordionSection>
     </div>
   );

--- a/src/hooks/useSimulation.ts
+++ b/src/hooks/useSimulation.ts
@@ -55,8 +55,11 @@ export type SimStats = {
   stripeOrderParam: number; // max_α sqrt(S(k_α)/N³) — detects layered phase
   /** S(k)/N³ along Γ→X→M→R→Γ; null until first measurement */
   skPath: Float32Array | null;
-  /** energy/site samples collected since last parameter change; null until ≥50 */
+  /** energy/site samples; null until ≥20 */
   energySamples: Float32Array | null;
+  /** magnetization samples; null until ≥20 */
+  magnetizationSamples: Float32Array | null;
+  histSamplesFilled: number;
 };
 
 export function useSimulation({
@@ -94,7 +97,8 @@ export function useSimulation({
   const skLastComputedSweepRef = useRef(-1);
   const stripeRef = useRef<number>(0);
   const energyBufRef = useRef(new Float32Array(ENERGY_BUFFER_SIZE));
-  const energySampleCountRef = useRef(0);
+  const magnetizationBufRef = useRef(new Float32Array(ENERGY_BUFFER_SIZE));
+  const histSampleCountRef = useRef(0);
   const lastParamsForHistRef = useRef<{ betaJ: number; betaJ2: number; betaH: number } | null>(null);
 
   paramsRef.current = { betaJ, betaJ2, betaH, tStar, sliceAxis, sliceIndex };
@@ -109,7 +113,7 @@ export function useSimulation({
     skLastComputedSweepRef.current = -1;
     stripeRef.current = 0;
     skPathDefRef.current = buildSkPath(newLat.latticeSize);
-    energySampleCountRef.current = 0;
+    histSampleCountRef.current = 0;
     lastParamsForHistRef.current = null;
 
     // (Re-)initialize WASM lattice from the new JS bytes.
@@ -196,14 +200,16 @@ export function useSimulation({
       if (didSweep && isFinite(tStar)) {
         const last = lastParamsForHistRef.current;
         if (!last || last.betaJ !== betaJ || last.betaJ2 !== betaJ2 || last.betaH !== betaH) {
-          energySampleCountRef.current = 0;
+          histSampleCountRef.current = 0;
           lastParamsForHistRef.current = { betaJ, betaJ2, betaH };
         }
-        energyBufRef.current[energySampleCountRef.current % ENERGY_BUFFER_SIZE] = energyPerSite;
-        energySampleCountRef.current++;
+        const pos = histSampleCountRef.current % ENERGY_BUFFER_SIZE;
+        energyBufRef.current[pos] = energyPerSite;
+        magnetizationBufRef.current[pos] = latticeRef.current.magnetization();
+        histSampleCountRef.current++;
       }
 
-      const filled = Math.min(energySampleCountRef.current, ENERGY_BUFFER_SIZE);
+      const filled = Math.min(histSampleCountRef.current, ENERGY_BUFFER_SIZE);
 
       onStatsRef.current({
         magnetization: latticeRef.current.magnetization(),
@@ -212,7 +218,9 @@ export function useSimulation({
         neelOrderParam: latticeRef.current.neelOrderParam(),
         stripeOrderParam: stripeRef.current,
         skPath: skPathRef.current,
-        energySamples: filled >= 50 ? energyBufRef.current.slice(0, filled) : null,
+        energySamples: filled >= 20 ? energyBufRef.current.slice(0, filled) : null,
+        magnetizationSamples: filled >= 20 ? magnetizationBufRef.current.slice(0, filled) : null,
+        histSamplesFilled: filled,
       });
 
       animId = requestAnimationFrame(tick);

--- a/src/hooks/useSimulation.ts
+++ b/src/hooks/useSimulation.ts
@@ -9,6 +9,7 @@ import type { WasmLattice } from "@/services/wasm-loader";
 const FRAMES_PER_SWEEP = 6; // one full lattice sweep every 6 frames (~10/s at 60 fps)
 const PIXELS_PER_SPIN = 16;
 const SF_SWEEP_INTERVAL = 5; // recompute S(k) path every N sweeps
+const ENERGY_BUFFER_SIZE = 512;
 
 // High-symmetry path Γ→X→M→R→Γ on the simple-cubic Brillouin zone.
 // Coordinates are in units of (2π/N), so (N/2) corresponds to k=π.
@@ -54,6 +55,8 @@ export type SimStats = {
   stripeOrderParam: number; // max_α sqrt(S(k_α)/N³) — detects layered phase
   /** S(k)/N³ along Γ→X→M→R→Γ; null until first measurement */
   skPath: Float32Array | null;
+  /** energy/site samples collected since last parameter change; null until ≥50 */
+  energySamples: Float32Array | null;
 };
 
 export function useSimulation({
@@ -90,6 +93,9 @@ export function useSimulation({
   const skPathDefRef = useRef<{ nx: number; ny: number; nz: number }[]>([]);
   const skLastComputedSweepRef = useRef(-1);
   const stripeRef = useRef<number>(0);
+  const energyBufRef = useRef(new Float32Array(ENERGY_BUFFER_SIZE));
+  const energySampleCountRef = useRef(0);
+  const lastParamsForHistRef = useRef<{ betaJ: number; betaJ2: number; betaH: number } | null>(null);
 
   paramsRef.current = { betaJ, betaJ2, betaH, tStar, sliceAxis, sliceIndex };
   runningRef.current = running;
@@ -103,6 +109,8 @@ export function useSimulation({
     skLastComputedSweepRef.current = -1;
     stripeRef.current = 0;
     skPathDefRef.current = buildSkPath(newLat.latticeSize);
+    energySampleCountRef.current = 0;
+    lastParamsForHistRef.current = null;
 
     // (Re-)initialize WASM lattice from the new JS bytes.
     // loadWasm() is cached after the first call.
@@ -134,6 +142,7 @@ export function useSimulation({
       const { betaJ, betaJ2, betaH, tStar, sliceAxis, sliceIndex } = paramsRef.current;
 
       frameRef.current++;
+      let didSweep = false;
       if (runningRef.current && frameRef.current % FRAMES_PER_SWEEP === 0) {
         const wl = wasmRef.current;
         if (wl) {
@@ -146,6 +155,7 @@ export function useSimulation({
           );
         }
         sweepsRef.current++;
+        didSweep = true;
       }
 
       const canvas = canvasRef.current;
@@ -179,15 +189,30 @@ export function useSimulation({
         stripeRef.current = lat.stripeOrderParam();
       }
 
+      const energyPerSite = isFinite(tStar)
+        ? (latticeRef.current.betaEnergy(betaJ, betaJ2, betaH) / latticeRef.current.spinCount) * tStar
+        : 0;
+
+      if (didSweep && isFinite(tStar)) {
+        const last = lastParamsForHistRef.current;
+        if (!last || last.betaJ !== betaJ || last.betaJ2 !== betaJ2 || last.betaH !== betaH) {
+          energySampleCountRef.current = 0;
+          lastParamsForHistRef.current = { betaJ, betaJ2, betaH };
+        }
+        energyBufRef.current[energySampleCountRef.current % ENERGY_BUFFER_SIZE] = energyPerSite;
+        energySampleCountRef.current++;
+      }
+
+      const filled = Math.min(energySampleCountRef.current, ENERGY_BUFFER_SIZE);
+
       onStatsRef.current({
         magnetization: latticeRef.current.magnetization(),
-        energyPerSite: isFinite(tStar)
-          ? (latticeRef.current.betaEnergy(betaJ, betaJ2, betaH) / latticeRef.current.spinCount) * tStar
-          : 0,
+        energyPerSite,
         sweeps: sweepsRef.current,
         neelOrderParam: latticeRef.current.neelOrderParam(),
         stripeOrderParam: stripeRef.current,
         skPath: skPathRef.current,
+        energySamples: filled >= 50 ? energyBufRef.current.slice(0, filled) : null,
       });
 
       animId = requestAnimationFrame(tick);


### PR DESCRIPTION
## Summary

- Collects `energyPerSite` samples into a 512-entry ring buffer on each Metropolis sweep
- Buffer resets automatically when simulation parameters (T*, J₂/J₁, h) change
- New **Energy Distribution** accordion panel shows a bar histogram + Gaussian fit overlay
- Gaussian fit lets users visually verify the Boltzmann distribution holds (ergodic hypothesis)

## Test plan

- [ ] Run simulation in ferromagnetic phase (T* < T*_c): histogram should show narrow peak at negative E
- [ ] Run in paramagnetic phase (T* >> T*_c): broader distribution closer to zero
- [ ] Change T* slider mid-run: histogram resets and rebuilds
- [ ] Gaussian curve should track the histogram peak after ~50 sweeps

🤖 Generated with [Claude Code](https://claude.com/claude-code)