### PR TITLE
test: add unit tests for metropolis sweeps and structureFactorAt

### DIFF
--- a/src/services/__tests__/metropolis.test.ts
+++ b/src/services/__tests__/metropolis.test.ts
@@ -6,30 +6,36 @@ import {
   sublatticeSweepLattice,
 } from "../metropolis";
 
+function xorshift(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s ^= s << 13; s ^= s >> 17; s ^= s << 5;
+    return (s >>> 0) / 2 ** 32;
+  };
+}
+
 describe("simulateMetropoliseSweepLattice", () => {
   it("returns a new SpinLattice, not the same object", () => {
     const lat = SpinLattice.createFerro(4);
-    const result = simulateMetropoliseSweepLattice(lat, 1, 0, 0);
+    const result = simulateMetropoliseSweepLattice(lat, 1, 0, 0, xorshift(1));
     expect(result).not.toBe(lat);
   });
 
   it("does not mutate the input lattice", () => {
     const lat = SpinLattice.createFerro(4);
-    simulateMetropoliseSweepLattice(lat, 1, 0, 0);
+    simulateMetropoliseSweepLattice(lat, 1, 0, 0, xorshift(2));
     expect(lat.magnetization()).toBeCloseTo(1);
   });
 
   it("preserves FM order at T→0 (large betaJ): magnetization stays 1", () => {
-    // At betaJ=100, flip acceptance for aligned site ≈ exp(-1200) ≈ 0
     const lat = SpinLattice.createFerro(4);
-    const result = simulateMetropoliseSweepLattice(lat, 100, 0, 0);
+    const result = simulateMetropoliseSweepLattice(lat, 100, 0, 0, xorshift(3));
     expect(result.magnetization()).toBeCloseTo(1);
   });
 
   it("preserves AFM Néel order at T→0 with betaJ2 coupling", () => {
-    // Néel state is ground state for betaJ2 >> |betaJ|; large betaJ2 locks it in
     const lat = SpinLattice.createNeel(4);
-    const result = simulateMetropoliseSweepLattice(lat, 0, 100, 0);
+    const result = simulateMetropoliseSweepLattice(lat, 0, 100, 0, xorshift(4));
     expect(Math.abs(result.neelOrderParam())).toBeCloseTo(1);
   });
 });
@@ -37,7 +43,7 @@ describe("simulateMetropoliseSweepLattice", () => {
 describe("simulateMetropolis", () => {
   it("sweeps=0 returns a copy with identical spin configuration", () => {
     const lat = SpinLattice.createFerro(4);
-    const result = simulateMetropolis(lat, 1, 0, 0, 0);
+    const result = simulateMetropolis(lat, 1, 0, 0, 0, xorshift(5));
     expect(result).not.toBe(lat);
     for (let z = 0; z < 4; z++)
       for (let y = 0; y < 4; y++)
@@ -47,13 +53,13 @@ describe("simulateMetropolis", () => {
 
   it("does not mutate the input across multiple sweeps", () => {
     const lat = SpinLattice.createFerro(4);
-    simulateMetropolis(lat, 1, 0, 0, 3);
+    simulateMetropolis(lat, 1, 0, 0, 3, xorshift(6));
     expect(lat.magnetization()).toBeCloseTo(1);
   });
 
   it("preserves FM order at T→0 across multiple sweeps", () => {
     const lat = SpinLattice.createFerro(4);
-    const result = simulateMetropolis(lat, 100, 0, 0, 5);
+    const result = simulateMetropolis(lat, 100, 0, 0, 5, xorshift(7));
     expect(result.magnetization()).toBeCloseTo(1);
   });
 });
@@ -61,7 +67,7 @@ describe("simulateMetropolis", () => {
 describe("sublatticeSweepLattice", () => {
   it("returns a new SpinLattice, not the same object", () => {
     const lat = SpinLattice.createFerro(4);
-    const result = sublatticeSweepLattice(lat, 1, 0, 0);
+    const result = sublatticeSweepLattice(lat, 1, 0, 0, xorshift(8));
     expect(result).not.toBe(lat);
   });
 
@@ -81,7 +87,6 @@ describe("sublatticeSweepLattice", () => {
 
   it("T→∞: all-down flips to all-up", () => {
     const lat = SpinLattice.createFerro(4);
-    // manually set all-down via negating ferro
     for (let z = 0; z < 4; z++)
       for (let y = 0; y < 4; y++)
         for (let x = 0; x < 4; x++)
@@ -92,13 +97,13 @@ describe("sublatticeSweepLattice", () => {
 
   it("preserves FM order at T→0 (large betaJ)", () => {
     const lat = SpinLattice.createFerro(4);
-    const result = sublatticeSweepLattice(lat, 100, 0, 0);
+    const result = sublatticeSweepLattice(lat, 100, 0, 0, xorshift(9));
     expect(result.magnetization()).toBeCloseTo(1);
   });
 
   it("preserves Néel order at T→0 (large |betaJ2|, AFM NNN)", () => {
     const lat = SpinLattice.createNeel(4);
-    const result = sublatticeSweepLattice(lat, 0, 100, 0);
+    const result = sublatticeSweepLattice(lat, 0, 100, 0, xorshift(10));
     expect(Math.abs(result.neelOrderParam())).toBeCloseTo(1);
   });
 });

--- a/src/services/__tests__/metropolis.test.ts
+++ b/src/services/__tests__/metropolis.test.ts
@@ -71,15 +71,15 @@ describe("sublatticeSweepLattice", () => {
     expect(lat.magnetization()).toBeCloseTo(1);
   });
 
-  it("with J=h=0: all-up flips to all-down (ΔE=0 so every site is accepted)", () => {
-    // When all couplings are zero, energyAt=0 for every site, ΔE=−2×0=0≤0,
-    // so every spin is marked for flipping — a deterministic full-lattice flip.
+  it("T→∞ (betaJ=betaJ2=betaH=0): all-up flips to all-down (ΔE=0 so every site is accepted)", () => {
+    // At infinite temperature K₁=K₂=h̃=0, so energyAt=0 for every site,
+    // ΔE=−2×0=0≤0 — every spin is marked for flipping deterministically.
     const lat = SpinLattice.createFerro(4);
     const result = sublatticeSweepLattice(lat, 0, 0, 0);
     expect(result.magnetization()).toBeCloseTo(-1);
   });
 
-  it("with J=h=0: all-down flips to all-up", () => {
+  it("T→∞: all-down flips to all-up", () => {
     const lat = SpinLattice.createFerro(4);
     // manually set all-down via negating ferro
     for (let z = 0; z < 4; z++)

--- a/src/services/__tests__/metropolis.test.ts
+++ b/src/services/__tests__/metropolis.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { SpinLattice } from "../spin-lattice";
+import {
+  simulateMetropoliseSweepLattice,
+  simulateMetropolis,
+  sublatticeSweepLattice,
+} from "../metropolis";
+
+describe("simulateMetropoliseSweepLattice", () => {
+  it("returns a new SpinLattice, not the same object", () => {
+    const lat = SpinLattice.createFerro(4);
+    const result = simulateMetropoliseSweepLattice(lat, 1, 0, 0);
+    expect(result).not.toBe(lat);
+  });
+
+  it("does not mutate the input lattice", () => {
+    const lat = SpinLattice.createFerro(4);
+    simulateMetropoliseSweepLattice(lat, 1, 0, 0);
+    expect(lat.magnetization()).toBeCloseTo(1);
+  });
+
+  it("preserves FM order at T→0 (large betaJ): magnetization stays 1", () => {
+    // At betaJ=100, flip acceptance for aligned site ≈ exp(-1200) ≈ 0
+    const lat = SpinLattice.createFerro(4);
+    const result = simulateMetropoliseSweepLattice(lat, 100, 0, 0);
+    expect(result.magnetization()).toBeCloseTo(1);
+  });
+
+  it("preserves AFM Néel order at T→0 with betaJ2 coupling", () => {
+    // Néel state is ground state for betaJ2 >> |betaJ|; large betaJ2 locks it in
+    const lat = SpinLattice.createNeel(4);
+    const result = simulateMetropoliseSweepLattice(lat, 0, 100, 0);
+    expect(Math.abs(result.neelOrderParam())).toBeCloseTo(1);
+  });
+});
+
+describe("simulateMetropolis", () => {
+  it("sweeps=0 returns a copy with identical spin configuration", () => {
+    const lat = SpinLattice.createFerro(4);
+    const result = simulateMetropolis(lat, 1, 0, 0, 0);
+    expect(result).not.toBe(lat);
+    for (let z = 0; z < 4; z++)
+      for (let y = 0; y < 4; y++)
+        for (let x = 0; x < 4; x++)
+          expect(result.getSpin({ x, y, z })).toBe(lat.getSpin({ x, y, z }));
+  });
+
+  it("does not mutate the input across multiple sweeps", () => {
+    const lat = SpinLattice.createFerro(4);
+    simulateMetropolis(lat, 1, 0, 0, 3);
+    expect(lat.magnetization()).toBeCloseTo(1);
+  });
+
+  it("preserves FM order at T→0 across multiple sweeps", () => {
+    const lat = SpinLattice.createFerro(4);
+    const result = simulateMetropolis(lat, 100, 0, 0, 5);
+    expect(result.magnetization()).toBeCloseTo(1);
+  });
+});
+
+describe("sublatticeSweepLattice", () => {
+  it("returns a new SpinLattice, not the same object", () => {
+    const lat = SpinLattice.createFerro(4);
+    const result = sublatticeSweepLattice(lat, 1, 0, 0);
+    expect(result).not.toBe(lat);
+  });
+
+  it("does not mutate the input lattice", () => {
+    const lat = SpinLattice.createFerro(4);
+    sublatticeSweepLattice(lat, 0, 0, 0);
+    expect(lat.magnetization()).toBeCloseTo(1);
+  });
+
+  it("with J=h=0: all-up flips to all-down (ΔE=0 so every site is accepted)", () => {
+    // When all couplings are zero, energyAt=0 for every site, ΔE=−2×0=0≤0,
+    // so every spin is marked for flipping — a deterministic full-lattice flip.
+    const lat = SpinLattice.createFerro(4);
+    const result = sublatticeSweepLattice(lat, 0, 0, 0);
+    expect(result.magnetization()).toBeCloseTo(-1);
+  });
+
+  it("with J=h=0: all-down flips to all-up", () => {
+    const lat = SpinLattice.createFerro(4);
+    // manually set all-down via negating ferro
+    for (let z = 0; z < 4; z++)
+      for (let y = 0; y < 4; y++)
+        for (let x = 0; x < 4; x++)
+          lat.setSpin({ x, y, z }, -1);
+    const result = sublatticeSweepLattice(lat, 0, 0, 0);
+    expect(result.magnetization()).toBeCloseTo(1);
+  });
+
+  it("preserves FM order at T→0 (large betaJ)", () => {
+    const lat = SpinLattice.createFerro(4);
+    const result = sublatticeSweepLattice(lat, 100, 0, 0);
+    expect(result.magnetization()).toBeCloseTo(1);
+  });
+
+  it("preserves Néel order at T→0 (large |betaJ2|, AFM NNN)", () => {
+    const lat = SpinLattice.createNeel(4);
+    const result = sublatticeSweepLattice(lat, 0, 100, 0);
+    expect(Math.abs(result.neelOrderParam())).toBeCloseTo(1);
+  });
+});

--- a/src/services/__tests__/spin-lattice.test.ts
+++ b/src/services/__tests__/spin-lattice.test.ts
@@ -235,6 +235,38 @@ describe("SpinLattice – order parameters", () => {
 
 // -------------------------------------------------------------------------
 
+describe("SpinLattice – structureFactorAt", () => {
+  it("S(0,0,0) for all-up ferro equals N³ (ferromagnetic peak at Γ)", () => {
+    const N = 4;
+    const lat = SpinLattice.createFerro(N);
+    // re = Σ spin × cos(0) = N³, im = Σ spin × sin(0) = 0 → S = N³²/N³ = N³
+    expect(lat.structureFactorAt(0, 0, 0)).toBeCloseTo(N ** 3);
+  });
+
+  it("S(H,H,H) for perfect Néel state equals N³ (AFM peak at R-point)", () => {
+    const N = 4;
+    const H = N / 2; // π/a wavevector index
+    const lat = SpinLattice.createNeel(N);
+    // Phase cos(π(x+y+z)) = (-1)^(x+y+z) = spin at each site → all terms = +1
+    expect(lat.structureFactorAt(H, H, H)).toBeCloseTo(N ** 3);
+  });
+
+  it("S(H,0,0) for perfect layered state equals N³ (stripe peak at X-point)", () => {
+    const N = 4;
+    const H = N / 2;
+    const lat = SpinLattice.createLayered(N);
+    // Layered s = (-1)^x, phase cos(πx) = (-1)^x → all terms = +1
+    expect(lat.structureFactorAt(H, 0, 0)).toBeCloseTo(N ** 3);
+  });
+
+  it("S(0,0,0) for all-up ferro with N=2 equals 8", () => {
+    const lat = SpinLattice.createFerro(2);
+    expect(lat.structureFactorAt(0, 0, 0)).toBeCloseTo(8);
+  });
+});
+
+// -------------------------------------------------------------------------
+
 describe("SpinLattice – energyAt", () => {
   it("all-up lattice: flipping any site raises energy by 12 betaJ (6 NN each contributing 2)", () => {
     const N = 4;

--- a/src/services/metropolis.ts
+++ b/src/services/metropolis.ts
@@ -4,19 +4,20 @@ export function simulateMetropoliseSweepLattice(
   lattice: SpinLattice,
   betaJ: number,
   betaJ2: number,
-  betaH: number
+  betaH: number,
+  rng: () => number = Math.random,
 ) {
   const lat = new SpinLattice(lattice);
   const N = lattice.latticeSize;
   for (let _ = 0; _ < N ** 3; _++) {
-    const x = Math.floor(Math.random() * N);
-    const y = Math.floor(Math.random() * N);
-    const z = Math.floor(Math.random() * N);
+    const x = Math.floor(rng() * N);
+    const y = Math.floor(rng() * N);
+    const z = Math.floor(rng() * N);
     const oldEnergy = lat.energyAt({ x, y, z }, betaJ, betaJ2, betaH);
     lat.flipSpin({ x, y, z });
     const newEnergy = lat.energyAt({ x, y, z }, betaJ, betaJ2, betaH);
     const deltaEnergy = newEnergy - oldEnergy;
-    if (deltaEnergy > 0 && Math.random() > Math.exp(-deltaEnergy)) {
+    if (deltaEnergy > 0 && rng() > Math.exp(-deltaEnergy)) {
       lat.flipSpin({ x, y, z });
     }
   }
@@ -28,10 +29,11 @@ export function simulateMetropolis(
   betaJ: number,
   betaJ2: number,
   betaH: number,
-  sweeps: number
+  sweeps: number,
+  rng: () => number = Math.random,
 ): SpinLattice {
   return Array.from({ length: sweeps }).reduce<SpinLattice>(
-    (acc) => simulateMetropoliseSweepLattice(acc, betaJ, betaJ2, betaH),
+    (acc) => simulateMetropoliseSweepLattice(acc, betaJ, betaJ2, betaH, rng),
     new SpinLattice(lattice)
   );
 }
@@ -44,6 +46,7 @@ export function sublatticeSweepLattice(
   betaJ: number,
   betaJ2: number,
   betaH: number,
+  rng: () => number = Math.random,
 ): SpinLattice {
   const lat = new SpinLattice(lattice);
   const N = lat.latticeSize;
@@ -53,7 +56,7 @@ export function sublatticeSweepLattice(
     for (let y = 0; y < N; y++)
       for (let x = 0; x < N; x++) {
         const delta = -2 * lat.energyAt({ x, y, z }, betaJ, betaJ2, betaH);
-        if (delta <= 0 || Math.random() < Math.exp(-delta))
+        if (delta <= 0 || rng() < Math.exp(-delta))
           toFlip.push({ x, y, z });
       }
 


### PR DESCRIPTION
## Summary

- Add `metropolis.test.ts` covering `simulateMetropoliseSweepLattice`, `simulateMetropolis`, and `sublatticeSweepLattice` (immutability, T→0 order preservation, and a deterministic J=h=0 full-flip test)
- Add `structureFactorAt` tests to `spin-lattice.test.ts` verifying Γ-point, R-point (Néel), and X-point (stripe) peaks

## Test plan

- [x] All 57 tests pass (`npm test`)
- [x] Deterministic case: `sublatticeSweepLattice` with J=h=0 flips every spin (ΔE=0 always accepted)
- [x] Physical cases: FM and AFM order locked in at T→0 (large coupling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)