### PR TITLE
fix: replace jSign useEffect with direct event handler

### DIFF
--- a/src/components/ising-page.tsx
+++ b/src/components/ising-page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useRef, useState, useMemo, useEffect } from "react";
+import React, { useRef, useState, useMemo } from "react";
 import Image from "next/image";
 import { useSimulation, SimStats, skPathSegments } from "@/hooks/useSimulation";
 import { T_STAR_CRITICAL } from "@/constants";
@@ -119,16 +119,10 @@ export function IsingPage({
   const handleReset = () =>
     setWarmSpins(new Uint8Array(SpinLattice.createRandom(latticeSize)));
 
-  // Reinitialize spins when J₁ sign flips — changing sign means swapping the
-  // physical sample (FM ↔ AFM), so the current spin configuration is no longer
-  // meaningful.  Using a ref prevents firing on the initial render and is safe
-  // under React strict mode (second invocation sees prevJSign already updated).
-  const prevJSignRef = useRef<1 | -1>(jSign);
-  useEffect(() => {
-    if (prevJSignRef.current === jSign) return;
-    prevJSignRef.current = jSign;
+  const handleSetJSign = (v: 1 | -1) => {
+    setJSign(v);
     setWarmSpins(new Uint8Array(SpinLattice.createRandom(latticeSize)));
-  }, [jSign, latticeSize]);
+  };
 
   const phaseDiagramData = phaseDiagramRaw as unknown as PhaseDiagramData;
 
@@ -177,7 +171,7 @@ export function IsingPage({
           tStar={tStar}
           setTStar={setTStar}
           jSign={jSign}
-          setJSign={setJSign}
+          setJSign={handleSetJSign}
           j2OverJ1={j2OverJ1}
           setJ2OverJ1={setJ2OverJ1}
           h={h}

--- a/src/hooks/useSimulation.ts
+++ b/src/hooks/useSimulation.ts
@@ -114,6 +114,7 @@ export function useSimulation({
       const seed = BigInt(Math.floor(Math.random() * Number.MAX_SAFE_INTEGER));
       wasmRef.current?.free();
       wasmRef.current = W.from_bytes(bytes, newLat.latticeSize, seed);
+      kickRef.current();
     });
   }, [initialSpins]);
 


### PR DESCRIPTION
## Summary
- `jSign` の変化でスピンを再初期化していた `useEffect` を削除
- J₁ sign のラジオボタン onChange は純粋なユーザーイベントなので、`handleSetJSign` ハンドラーで `setJSign` と `setWarmSpins` を直接呼ぶ形に修正
- `prevJSignRef`（初回レンダリングガード用）も不要になったので削除
- `useEffect`/`useRef` の import も整理

## Test plan
- [ ] Ferro → Antiferro に切り替えると格子がランダム初期化されることを確認
- [ ] Antiferro → Ferro でも同様に確認
- [ ] 初回レンダリングで意図せずリセットされないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)