### PR TITLE
fix: show C(r) at T*=∞

### DIFF
--- a/src/hooks/useSimulation.ts
+++ b/src/hooks/useSimulation.ts
@@ -261,12 +261,12 @@ export function useSimulation({
         : (tStar > 0 && magnetizationStdDev !== null)
           ? spinCount * magnetizationStdDev ** 2 / tStar
           : null;
-      const skReady = (
-        isFinite(tStar) &&
+      const skBufReady = (
         skSumCountRef.current >= 10 &&
         skSumBufRef.current !== null &&
         skPathDefRef.current.length > 0
       );
+      const skReady = isFinite(tStar) && skBufReady;
       // S_conn(Γ) = N³·Var(M): connected structure factor at Γ, used for FM second-moment ξ.
       const sConnGamma = magnetizationStdDev !== null
         ? spinCount * magnetizationStdDev ** 2
@@ -281,7 +281,7 @@ export function useSimulation({
           neelMag,
           stripeRef.current,
         ) : null;
-      const correlationData = skReady ? computeCorrelationData(
+      const correlationData = skBufReady ? computeCorrelationData(
         skSumBufRef.current!,
         skSumCountRef.current,
         skPathDefRef.current,


### PR DESCRIPTION
## Summary

- `skReady` combined buffer-readiness with the finite-T guard, so `correlationData` was never computed at T*=∞
- Split into `skBufReady` (buffer has ≥10 samples, path is set) and `skReady` (same + `isFinite(tStar)`)
- `correlationData` now uses `skBufReady`; `correlationLength` still uses `skReady` and returns 0 at T*=∞

At T*=∞ the expected C(r) is delta-function-like (1 at r=0, ~0 elsewhere), which is now rendered.

## Test plan

- [ ] Start simulation at T*=∞ — C(r) panel shows a curve after ~10 S(k) samples
- [ ] Finite-T cases (e.g. T*=0.5, T*=T_c) still display C(r) and ξ normally
- [ ] ξ shows 0 at T*=∞ (unchanged)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)