### PR TITLE
feat: allow negative external field h (range −2 to +2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The high-temperature limit collapses to the single point K₁ = K₂ = h̃ = 0 r
 | ------------------- | --------------------------------------- | ---------------- |
 | T\* = k_BT / \|J₁\| | Reduced temperature (always positive)   | Log-scale slider |
 | J₁_sign ∈ {+1, −1}  | FM / AFM toggle                         | Radio buttons    |
-| h                   | External field (units of \|J₁\|)        | Slider           |
+| h ∈ [−2, +2]        | External field (units of \|J₁\|)        | Slider           |
 | J₂                  | Next-nearest coupling (units of \|J₁\|) | Slider           |
 
 Conversion from UI to simulation core:

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ export const T_STAR_LOG_MIN = 0.5;   // lowest finite T*
 export const T_STAR_LOG_MAX = 20.0;  // highest finite T* (∞ is a separate button)
 
 // External field h (in units of |J₁|)
-export const H_MIN = 0;
+export const H_MIN = -2.0;
 export const H_MAX = 2.0;
 export const H_STEP = 0.25;
 


### PR DESCRIPTION
## Summary

- `H_MIN` を `0` から `-2.0` に変更し、外場 h に負の値を許可
- README の UI パラメータ表に h の範囲 `[−2, +2]` を明記

## Physics motivation

外場 h が負の場合、スピンは h > 0 の場合と逆方向に整列しようとする。これにより、反強磁性秩序との競合や磁化ヒステリシスのシミュレーションが可能になる。

## Test plan

- [ ] スライダーが −2.0 から 2.0 の範囲で動作することを確認
- [ ] h < 0 のとき磁化が負方向に傾くことを確認
- [ ] h = 0 での挙動が従来と変わらないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)