### PR TITLE
feat: deploy to GitHub Pages via GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,75 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build WASM
+        working-directory: ising-core
+        run: wasm-pack build --target web --out-dir pkg
+
+      - name: Copy WASM to public
+        run: |
+          cp ising-core/pkg/ising_core.js public/wasm/
+          cp ising-core/pkg/ising_core_bg.wasm public/wasm/
+          cp ising-core/pkg/ising_core.d.ts public/wasm/
+          cp ising-core/pkg/ising_core_bg.wasm.d.ts public/wasm/
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        env:
+          NEXT_PUBLIC_BASE_PATH: /ising-model
+        run: pnpm build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
 const nextConfig: NextConfig = {
   output: "export",
   reactStrictMode: true,
+  basePath,
+  assetPrefix: basePath,
 };
 
 module.exports = nextConfig;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,8 +34,8 @@ export default function RootLayout({
             </Script>
           </>
         )}
-        <link rel="modulepreload" href="/wasm/ising_core.js" />
-        <link rel="preload" href="/wasm/ising_core_bg.wasm" as="fetch" crossOrigin="anonymous" />
+        <link rel="modulepreload" href={`${process.env.NEXT_PUBLIC_BASE_PATH || ""}/wasm/ising_core.js`} />
+        <link rel="preload" href={`${process.env.NEXT_PUBLIC_BASE_PATH || ""}/wasm/ising_core_bg.wasm`} as="fetch" crossOrigin="anonymous" />
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
         <link rel="alternate icon" href="/favicon.ico" sizes="16x16" />
       </head>

--- a/src/services/wasm-loader.ts
+++ b/src/services/wasm-loader.ts
@@ -19,10 +19,11 @@ let ready: Promise<WasmModule> | null = null;
 export function loadWasm(): Promise<WasmModule> {
   if (ready) return ready;
   ready = (async () => {
+    const base = process.env.NEXT_PUBLIC_BASE_PATH || "";
     const m = await import(
-      /* webpackIgnore: true */ "/wasm/ising_core.js" as string
+      /* webpackIgnore: true */ `${base}/wasm/ising_core.js` as string
     ) as WasmModule;
-    await m.default({ module_or_path: "/wasm/ising_core_bg.wasm" });
+    await m.default({ module_or_path: `${base}/wasm/ising_core_bg.wasm` });
     return m;
   })().catch((e) => { console.error("[wasm] load failed:", e); throw e; });
   return ready;


### PR DESCRIPTION
## Summary

- Add `.github/workflows/deploy.yml` — builds Rust/WASM with wasm-pack, then Next.js with `NEXT_PUBLIC_BASE_PATH=/ising-model`, and deploys the `out/` static export to GitHub Pages
- Update `next.config.ts` to set `basePath` and `assetPrefix` from `NEXT_PUBLIC_BASE_PATH`
- Update `wasm-loader.ts` and `layout.tsx` to prefix WASM paths with the base path

## Test plan

- [ ] On GitHub: Settings → Pages → Source → **GitHub Actions**
- [ ] Merge and confirm the workflow passes and the site loads at `https://nwatab.github.io/ising-model/`
- [ ] Verify local `pnpm build` still works (no `NEXT_PUBLIC_BASE_PATH` set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)