### PR TITLE
fix: GitHub icon not shown on GitHub Pages

### DIFF
--- a/src/components/ising-page.tsx
+++ b/src/components/ising-page.tsx
@@ -336,7 +336,7 @@ export function IsingPage({
               target="_blank"
               rel="noopener noreferrer"
             >
-              <Image src="/github-mark-white.svg" alt="GitHub" width={20} height={20} />
+              <Image src={`${process.env.NEXT_PUBLIC_BASE_PATH ?? ""}/github-mark-white.svg`} alt="GitHub" width={20} height={20} />
             </a>
           </div>
           {controlsContent}
@@ -355,7 +355,7 @@ export function IsingPage({
             target="_blank"
             rel="noopener noreferrer"
           >
-            <Image src="/github-mark-white.svg" alt="GitHub" width={20} height={20} />
+            <Image src={`${process.env.NEXT_PUBLIC_BASE_PATH ?? ""}/github-mark-white.svg`} alt="GitHub" width={20} height={20} />
           </a>
         </div>
         {controlsContent}


### PR DESCRIPTION
## Summary

- The GitHub icon next to the title was missing after migrating from Vercel to GitHub Pages
- Root cause: `<Image src="/github-mark-white.svg">` used an absolute path that ignored the `basePath` (`/ising-model`) set during the GitHub Pages build
- Fix: prefix the path with `process.env.NEXT_PUBLIC_BASE_PATH` so the resolved URL is `/ising-model/github-mark-white.svg` on GitHub Pages and `/github-mark-white.svg` elsewhere

## Test plan

- [ ] Deploy to GitHub Pages and confirm the GitHub icon appears next to the title on both mobile and desktop layouts
- [ ] Confirm local dev still works (icon loads at `/github-mark-white.svg`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)