### PR TITLE
docs: narrow README physics section to 3D, add GFM footnotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@ H = -J_1 \sum_{\langle ij \rangle} s_i s_j
     - h \sum_i s_i
 $$
 
-**Lattice:** 2D square or 3D simple-cubic with periodic boundary conditions. Sites are indexed by $i$ with integer coordinates $i_\alpha \in \{0, \dots, L-1\}$ in each spatial dimension.
+**Lattice:** 3D simple-cubic with periodic boundary conditions. Sites are indexed by $i$ with integer coordinates $(i_x, i_y, i_z) \in \{0, \dots, L-1\}^3$.
 
 | Symbol | Domain | Meaning |
 | ------ | ------ | ------- |
 | $s_i$ | $\{-1, +1\}$ | Ising spin on site $i$ |
-| $\langle ij \rangle$ | NN pairs (each counted once in the sum) | Coordination $z_1 = 4$ (2D square), $6$ (3D SC) |
-| $\langle\langle ij \rangle\rangle$ | NNN pairs (face-diagonal, each counted once) | Coordination $z_2 = 4$ (2D square), $12$ (3D SC) |
+| $\langle ij \rangle$ | NN pairs (each counted once) | Coordination $z_1 = 6$ |
+| $\langle\langle ij \rangle\rangle$ | NNN pairs (face-diagonal, each counted once) | Coordination $z_2 = 12$ |
 | $J_1$ | $\mathbb{R}$ | NN coupling. $J_1 > 0$: FM, $J_1 < 0$: AFM. The UI parameterization $T^* = k_B T/\lvert J_1\rvert$ excludes $J_1 = 0$. |
-| $J_2$ | $\mathbb{R}$ | NNN coupling. Frustration arises when $J_2 < 0$ (NNN-AFM) competes with NN ordering; see "Frustration boundaries" below for the classical critical lines. |
+| $J_2$ | $\mathbb{R}$ | NNN coupling. Frustration arises when $J_2 < 0$ competes with NN ordering; see "Frustration boundaries" below for the classical critical lines. |
 | $h$ | $\mathbb{R}$ | Uniform external field, in the same energy units as $J_1$ |
 
 ### Canonical ensemble
@@ -85,22 +85,26 @@ $$
 
 ### Critical points
 
-| Quantity            | 2D square              | 3D simple-cubic      |
-| ------------------- | ---------------------- | -------------------- |
-| T\*\_c (J₂ = h = 0) | 2.2692 (Onsager exact) | 4.5115 (MC estimate) |
-| K_c                 | 0.4407                 | 0.2217               |
-| Universality class  | 2D Ising               | 3D Ising             |
+| Quantity | Value |
+| -------- | ----- |
+| $T^*_c$ at $J_2 = h = 0$ | 4.5115 (MC estimate)[^onsager] |
+| $K_c$ | 0.2217 |
+| Universality class | 3D Ising |
+
+[^onsager]: For the 2D square lattice, Onsager (1944) gave the exact closed-form solution $T^*_c = 2/\ln(1+\sqrt{2}) \approx 2.2692$. No analogous closed-form solution is known in 3D; the value above is a high-precision Monte Carlo estimate.
 
 ### Frustration boundaries (T = 0, h = 0)
 
-The classical FM↔stripe and Néel↔stripe transitions occur at different J₂/\|J₁\| values depending on dimension and on the sign of J₁:
+The classical FM↔stripe and Néel↔stripe transitions occur at different $|J_2/J_1|$ values depending on the sign of $J_1$:
 
-| Regime                        | 2D square       | 3D simple-cubic     |
-| ----------------------------- | --------------- | ------------------- |
-| FM J₁ (>0) + AFM J₂ → stripe  | \|J₂/J₁\| = 1/2 | **\|J₂/J₁\| = 1/4** |
-| AFM J₁ (<0) + AFM J₂ → stripe | \|J₂/J₁\| = 1/2 | \|J₂/J₁\| = 1/2     |
+| Regime | Boundary |
+| ------ | -------- |
+| FM $J_1$ ($> 0$) + AFM $J_2$ → stripe | $|J_2/J_1| = 1/4$ |
+| AFM $J_1$ ($< 0$) + AFM $J_2$ → stripe | $|J_2/J_1| = 1/2$ |
 
-Near these boundaries the ground-state manifold is highly degenerate; Metropolis dynamics equilibrates very slowly and the simulation may freeze into mismatched domains.
+The asymmetry between the two regimes is a feature of the 3D simple-cubic lattice.[^2d-frustration] Near these boundaries the ground-state manifold is highly degenerate; Metropolis dynamics equilibrates very slowly and the simulation may freeze into mismatched domains.
+
+[^2d-frustration]: In the 2D square lattice both boundaries coincide at $|J_2/J_1| = 1/2$ by sublattice symmetry: the transformation $s_i \to (-1)^{i_x + i_y} s_i$ maps FM↔Néel while preserving the stripe state. The 3D analog $s_i \to (-1)^{i_x + i_y + i_z} s_i$ does not preserve the cubic stripe state, hence the splitting.
 
 ### Critical slowing down
 


### PR DESCRIPTION
## Summary

- Remove all 2D square lattice references from the Hamiltonian section (lattice description, symbol table, critical-point table, frustration-boundary table)
- Add `[^onsager]` footnote: explains Onsager's 2D exact solution and why no closed-form equivalent exists in 3D
- Add `[^2d-frustration]` footnote: explains why the two frustration boundaries coincide in 2D (sublattice symmetry) but split in 3D

## Test plan

- [ ] View PR on GitHub and confirm footnote references render as superscripts and footnote definitions appear at the bottom of each section
- [ ] Confirm all `$...$` math in footnotes renders via GitHub MathJax

🤖 Generated with [Claude Code](https://claude.com/claude-code)