### PR TITLE
fix: redraw canvas after resize to prevent black screen when paused

### DIFF
--- a/src/hooks/useSimulation.ts
+++ b/src/hooks/useSimulation.ts
@@ -125,6 +125,7 @@ export function useSimulation({
     const resize = () => {
       canvas.width = window.innerWidth;
       canvas.height = window.innerHeight;
+      kickRef.current();
     };
     resize();
     window.addEventListener("resize", resize);


### PR DESCRIPTION
## Summary

- Setting `canvas.width` or `canvas.height` always clears canvas content (HTML canvas spec)
- When the simulation is paused, the animation loop is stopped, so no frame is drawn after resize
- Added `kickRef.current()` in the resize handler to trigger one render frame after each resize

## Test plan

- [ ] Start simulation, pause it, then resize the browser window — canvas should still show spins
- [ ] Resize while running — should continue rendering normally
- [ ] Resize to smaller and larger sizes while paused

🤖 Generated with [Claude Code](https://claude.com/claude-code)