### PR TITLE
feat: apply Néel sublattice transform when J₁ sign flips at h=0

### DIFF
--- a/src/components/ising-page.tsx
+++ b/src/components/ising-page.tsx
@@ -121,11 +121,6 @@ export function IsingPage({
   const handleReset = () =>
     setWarmSpins(new Uint8Array(SpinLattice.createRandom(latticeSize)));
 
-  const handleSetJSign = (v: 1 | -1) => {
-    setJSign(v);
-    setWarmSpins(new Uint8Array(SpinLattice.createRandom(latticeSize)));
-  };
-
   const phaseDiagramData = phaseDiagramRaw as unknown as PhaseDiagramData;
 
   const [stats, setStats] = useState<SimStats>({
@@ -146,7 +141,7 @@ export function IsingPage({
     correlationData: null,
   });
 
-  useSimulation({
+  const { getSpins } = useSimulation({
     canvasRef,
     initialSpins: warmSpins,
     betaJ: K1,
@@ -158,6 +153,16 @@ export function IsingPage({
     running,
     onStats: setStats,
   });
+
+  // At h=0: Néel sublattice transform maps (J₁,J₂) equilibrium → (−J₁,J₂) without discarding domain structure.
+  // At h≠0: the transform produces a staggered field rather than the desired uniform field, so reset instead.
+  const handleSetJSign = (v: 1 | -1) => {
+    setJSign(v);
+    setWarmSpins(h === 0
+      ? SpinLattice.applyNeelTransform(getSpins())
+      : new Uint8Array(SpinLattice.createRandom(latticeSize))
+    );
+  };
 
   const phase = inferPhase(stats.magnetization, stats.neelOrderParam, stats.stripeOrderParam, jSign, stats.skPath, latticeSize);
   const tStarForDiagram = isFinite(tStar) ? tStar : 20;

--- a/src/hooks/useSimulation.ts
+++ b/src/hooks/useSimulation.ts
@@ -332,4 +332,6 @@ export function useSimulation({
 
   // Re-render once when the display slice changes while paused.
   useEffect(() => { kickRef.current(); }, [sliceAxis, sliceIndex]);
+
+  return { getSpins: () => new Uint8Array(latticeRef.current) };
 }

--- a/src/services/spin-lattice.ts
+++ b/src/services/spin-lattice.ts
@@ -76,6 +76,24 @@ export class SpinLattice extends BitPackedArray {
     return lat;
   }
 
+  // Maps (J₁, J₂) equilibrium → (−J₁, J₂) equilibrium at h=0.
+  // Applies σ'_i = (−1)^(x+y+z) σ_i by XOR-ing the odd-parity color blocks.
+  // Color-sorted layout: color c = ((x&1)<<2)|((y&1)<<1)|(z&1); odd-parity colors: 1,2,4,7.
+  static applyNeelTransform(spins: Uint8Array): Uint8Array {
+    const N = Math.round(Math.cbrt(spins.length * 8));
+    const M = N >> 1;
+    const blockBits = M * M * M;
+    const result = new Uint8Array(spins);
+    const fullBytes = Math.floor(blockBits / 8);
+    const rem = blockBits & 7;
+    for (const color of [1, 2, 4, 7]) {
+      const start = color * Math.ceil(blockBits / 8);
+      for (let i = start; i < start + fullBytes; i++) result[i] ^= 0xFF;
+      if (rem > 0) result[start + fullBytes] ^= (1 << rem) - 1;
+    }
+    return result;
+  }
+
   randomize(): this {
     const CHUNK = 65536;
     for (let offset = 0; offset < this.byteLength; offset += CHUNK) {


### PR DESCRIPTION
## Summary

- At h=0, flipping J₁'s sign now applies the Néel sublattice transform σ'ᵢ = (−1)^(x+y+z)·σᵢ instead of a random reset, preserving domain structure and mapping the (J₁,J₂) equilibrium directly to (−J₁,J₂)
- At h≠0 a random reset is used because the transform would produce a staggered field rather than the desired uniform-field equilibrium
- `useSimulation` now returns `getSpins()` so the caller can read live lattice bytes synchronously before the reset

## Physics

In the 3D SC lattice the nearest-neighbour bonds are always between even/odd parity sites (ε_i ε_j = −1) and next-nearest bonds always within same parity (ε_i ε_j = +1), so:

```
H(s; J₁, J₂) = H(σ; −J₁, J₂)
```

This makes the Néel transform the exact state-space isomorphism for J₁ sign flips at h=0. At low T this avoids re-running the full cooling process — the thermalized domain structure transfers instantly.

## Implementation

`SpinLattice.applyNeelTransform(spins)` exploits the color-sorted bit layout: the 8 sublattice color blocks are already contiguous in memory. Odd-parity colors (1, 2, 4, 7) are flipped by XOR-ing their bytes with `0xFF` — O(N³/64) byte operations total.

## Test plan

- [ ] FM ground state (low T, J₁>0, h=0): toggle J₁ sign → should see the Néel AFM checkerboard instantly, not a new random start
- [ ] AFM ground state (low T, J₁<0, h=0): toggle J₁ sign → should see FM domain instantly
- [ ] h≠0: toggle J₁ sign → random reset (current behavior preserved)
- [ ] TypeScript: `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)