### PR TITLE
fix: prevent WASM state corruption when initialSpins changes

### DIFF
--- a/src/hooks/useSimulation.ts
+++ b/src/hooks/useSimulation.ts
@@ -107,12 +107,16 @@ export function useSimulation({
     histSampleCountRef.current = 0;
     lastParamsForHistRef.current = null;
 
-    // (Re-)initialize WASM lattice from the new JS bytes.
-    // loadWasm() is cached after the first call.
+    // Capture bytes now — newLat === latticeRef.current, so a concurrent
+    // animation tick calling latticeRef.current.set(wl.data()) would mutate
+    // newLat before the .then() callback runs, producing stale WASM state.
+    const bytes = new Uint8Array(newLat);
+    // Null the old WASM immediately so the animation loop falls back to the
+    // JS lattice (which already holds the new state) until WASM is ready.
+    wasmRef.current?.free();
+    wasmRef.current = null;
     loadWasm().then(({ SpinLattice: W }) => {
-      const bytes = new Uint8Array(newLat);
       const seed = BigInt(Math.floor(Math.random() * Number.MAX_SAFE_INTEGER));
-      wasmRef.current?.free();
       wasmRef.current = W.from_bytes(bytes, newLat.latticeSize, seed);
       kickRef.current();
     });

--- a/src/services/__tests__/spin-lattice.test.ts
+++ b/src/services/__tests__/spin-lattice.test.ts
@@ -267,6 +267,43 @@ describe("SpinLattice – structureFactorAt", () => {
 
 // -------------------------------------------------------------------------
 
+describe("SpinLattice – applyNeelTransform", () => {
+  it("FM → Néel: all sites satisfy σ'_i = (−1)^(x+y+z) σ_i", () => {
+    const N = 4;
+    const ferro = SpinLattice.createFerro(N);
+    const result = new SpinLattice(SpinLattice.applyNeelTransform(new Uint8Array(ferro)));
+    for (let z = 0; z < N; z++)
+      for (let y = 0; y < N; y++)
+        for (let x = 0; x < N; x++) {
+          const expected = ((x + y + z) & 1) === 0 ? 1 : -1;
+          expect(result.getSpin({ x, y, z })).toBe(expected);
+        }
+  });
+
+  it("FM → Néel: neelOrderParam = ±1", () => {
+    const N = 4;
+    const result = new SpinLattice(
+      SpinLattice.applyNeelTransform(new Uint8Array(SpinLattice.createFerro(N)))
+    );
+    expect(Math.abs(result.neelOrderParam())).toBeCloseTo(1);
+  });
+
+  it("double application is identity", () => {
+    const N = 4;
+    const original = new Uint8Array(SpinLattice.createFerro(N));
+    const roundTrip = SpinLattice.applyNeelTransform(SpinLattice.applyNeelTransform(original));
+    expect(roundTrip).toEqual(original);
+  });
+
+  it("does not mutate the input array", () => {
+    const N = 4;
+    const input = new Uint8Array(SpinLattice.createFerro(N));
+    const before = input.slice();
+    SpinLattice.applyNeelTransform(input);
+    expect(input).toEqual(before);
+  });
+});
+
 describe("SpinLattice – energyAt", () => {
   it("all-up lattice: flipping any site raises energy by 12 betaJ (6 NN each contributing 2)", () => {
     const N = 4;


### PR DESCRIPTION
newLat === latticeRef.current, so the animation loop's latticeRef.current.set(wl.data()) mutates newLat in-place. The old code captured bytes inside .then(), which could execute after that mutation, causing WASM to be re-initialized from the pre-transform (overwritten) state rather than the intended state.

Fix: capture bytes synchronously and null wasmRef.current before the async load so the JS lattice (already holding the new state) is used for rendering until WASM is ready.

Also adds tests verifying applyNeelTransform correctness: FM→Néel mapping, neelOrderParam = ±1, double-application identity, and input immutability.